### PR TITLE
Reuse connection during validation

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -114,7 +114,7 @@ impl<S, C: ClientExt> GenericConnection<C, S> {
     #[maybe_async]
     pub async fn validate_server(&self) -> Result<(), ClientError> {
         let arango_url = self.arango_url.as_str();
-        let client = C::new(None)?;
+        let client = &self.session;
         let resp = client.get(arango_url.parse().unwrap(), "").await?;
         // have `Server` in header
         match resp.headers().get(SERVER) {


### PR DESCRIPTION
When using `arangors` with connection pools such as `mobc`, connection validation takes place before a connection can be used. The current validation function seems to spawn a new client for every validation. This significantly slows down performance.