### PR TITLE
Add collection information

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -165,8 +165,10 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn document_count(&self) {
-        unimplemented!()
+    pub async fn document_count(&self) -> Result<CollectionDetails, ClientError> {
+        let url = self.base_url.join(&format!("count")).unwrap();
+        let resp: CollectionDetails = serialize_response(self.session.get(url, "").await?.text())?;
+        Ok(resp)
     }
     /// Fetch the statistics of a collection
     ///

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -44,14 +44,14 @@ pub struct CollectionDetails {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArangoIndex {
-    count: Option<u32>,
-    size: Option<u32>,
+    pub count: Option<u32>,
+    pub size: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Figures {
-    indexes: ArangoIndex,
+    pub indexes: ArangoIndex,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -200,8 +200,11 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn statistics(&self) {
-        unimplemented!()
+    pub async fn statistics(&self) -> Result<CollectionStatistics, ClientError> {
+        let url = self.base_url.join(&format!("figures")).unwrap();
+        let resp: CollectionStatistics =
+            serialize_response(self.session.get(url, "").await?.text())?;
+        Ok(resp)
     }
 
     /// Retrieve the collections revision id

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -238,8 +238,10 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn revision_id(&self) {
-        unimplemented!()
+    pub async fn revision_id(&self) -> Result<CollectionRevision, ClientError> {
+        let url = self.base_url.join(&format!("revision")).unwrap();
+        let resp: CollectionRevision = serialize_response(self.session.get(url, "").await?.text())?;
+        Ok(resp)
     }
     /// Fetch a checksum for the specified collection
     ///

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -40,6 +40,39 @@ pub struct CollectionDetails {
     pub wait_for_sync: bool,
     pub write_concern: u16,
 }
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArangoIndex {
+    count: Option<u32>,
+    size: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Figures {
+    indexes: ArangoIndex,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionStatistics {
+    /// The number of documents currently present in the collection.
+    pub count: Option<u32>,
+    /// metrics of the collection
+    pub figures: Figures,
+    pub cache_enabled: bool,
+    pub globally_unique_id: String,
+    pub id: String,
+    pub is_system: bool,
+    pub key_options: CollectionKeyOptions,
+    pub name: String,
+    pub object_id: String,
+    pub status: u16,
+    pub status_string: String,
+    pub r#type: u16,
+    pub wait_for_sync: bool,
+    pub write_concern: u16,
+}
 
 #[derive(Debug, Clone)]
 pub struct Collection<'a, C: ClientExt> {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -281,7 +281,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn checksum(&self) -> Result<CollectionChecksum, ClientError> {
-        self.checksum_with_options(None, None).await
+        self.checksum_with_options(false, false).await
     }
 
     // By setting the optional query parameter withRevisions to true, then revision
@@ -293,16 +293,15 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn checksum_with_options(
         &self,
-        with_revisions: Option<bool>,
-        with_data: Option<bool>,
+        with_revisions: bool,
+        with_data: bool,
     ) -> Result<CollectionChecksum, ClientError> {
         let mut query_parameters = "".to_owned();
 
-        if with_revisions.is_some() || with_data.is_some() {
+        if with_revisions == true || with_data == true {
             query_parameters.push_str(&format!(
                 "?withRevisions={}&withData={}",
-                with_revisions.unwrap_or(false),
-                with_data.unwrap_or(false)
+                with_revisions, with_data
             ));
         }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -75,6 +75,28 @@ pub struct CollectionStatistics {
     pub write_concern: u16,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionRevision {
+    // pub uses_revisions_as_document_ids: Option<bool>,
+    // pub sync_by_revision: bool,
+    // pub min_revision: u32,
+    /// These 3 properties are for Arangodb 3.7
+    pub revision: String,
+    pub cache_enabled: bool,
+    pub globally_unique_id: String,
+    pub id: String,
+    pub is_system: bool,
+    pub key_options: CollectionKeyOptions,
+    pub name: String,
+    pub object_id: String,
+    pub status: u16,
+    pub status_string: String,
+    pub r#type: u16,
+    pub wait_for_sync: bool,
+    pub write_concern: u16,
+}
+
 #[derive(Debug, Clone)]
 pub struct Collection<'a, C: ClientExt> {
     id: String,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -40,6 +40,7 @@ pub struct CollectionDetails {
     pub wait_for_sync: bool,
     pub write_concern: u16,
 }
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArangoIndex {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -97,6 +97,19 @@ pub struct CollectionRevision {
     pub write_concern: u16,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionChecksum {
+    pub revision: String,
+    pub checksum: String,
+    pub globally_unique_id: String,
+    pub id: String,
+    pub is_system: bool,
+    pub name: String,
+    pub status: u16,
+    pub r#type: u16,
+}
+
 #[derive(Debug, Clone)]
 pub struct Collection<'a, C: ClientExt> {
     id: String,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -296,19 +296,14 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         with_revisions: bool,
         with_data: bool,
     ) -> Result<CollectionChecksum, ClientError> {
-        let mut query_parameters = "".to_owned();
+        let mut url = self.base_url.join("checksum").unwrap();
 
-        if with_revisions == true || with_data == true {
-            query_parameters.push_str(&format!(
-                "?withRevisions={}&withData={}",
-                with_revisions, with_data
-            ));
+        if with_revisions == true {
+            url.query_pairs_mut().append_pair("withRevisions", "true");
         }
-
-        let url = self
-            .base_url
-            .join(&format!("checksum{}", query_parameters))
-            .unwrap();
+        if with_data == true {
+            url.query_pairs_mut().append_pair("withData", "true");
+        }
 
         let resp: CollectionChecksum = serialize_response(self.session.get(url, "").await?.text())?;
         Ok(resp)

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -280,8 +280,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn checksum(&self) {
-        unimplemented!()
+    pub async fn checksum(&self) -> Result<CollectionChecksum, ClientError> {
+        self.checksum_with_options(None, None).await
     }
 
     // By setting the optional query parameter withRevisions to true, then revision

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -300,7 +300,7 @@ async fn test_get_checksum() {
     assert_eq!(result.checksum, "0");
     assert_eq!(result.checksum.is_empty(), false);
 
-    let checksum = coll.checksum_with_options(Some(true), Some(true)).await;
+    let checksum = coll.checksum_with_options(true, true).await;
 
     let updated_result = checksum.unwrap();
     assert_eq!(updated_result.revision, "0");

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -191,9 +191,9 @@ async fn test_get_statistics() {
     let coll = database.collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
     let coll = coll.unwrap();
-    let count = coll.statistics().await;
+    let statistics = coll.statistics().await;
 
-    let result = count.unwrap();
+    let result = statistics.unwrap();
     eprintln!("{:?}", result);
     assert_eq!(result.count, Some(0));
     assert_eq!(result.name, collection_name);
@@ -241,9 +241,9 @@ async fn test_get_revision_id() {
     let coll = database.collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
     let coll = coll.unwrap();
-    let count = coll.revision_id().await;
+    let revision = coll.revision_id().await;
 
-    let result = count.unwrap();
+    let result = revision.unwrap();
     eprintln!("{:?}", result);
     assert_eq!(result.revision, "0");
     assert_eq!(result.name, collection_name);

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -212,3 +212,50 @@ async fn test_get_statistics() {
     let coll = database.drop_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 }
+
+#[maybe_async::test(
+    sync = r#"any(feature="reqwest_blocking")"#,
+    async = r#"any(feature="reqwest_async")"#,
+    test = "tokio::test"
+)]
+#[cfg_attr(feature = "surf_async", maybe_async::must_be_async, async_std::test)]
+async fn test_get_revision_id() {
+    test_setup();
+    let host = get_arangodb_host();
+    let user = get_normal_user();
+    let password = get_normal_password();
+
+    let collection_name = "test_collection_revision_id";
+
+    let conn = Connection::establish_jwt(&host, &user, &password)
+        .await
+        .unwrap();
+    let mut database = conn.db("test_db").await.unwrap();
+
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), true);
+
+    let coll = database.create_collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+
+    let coll = database.collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+    let coll = coll.unwrap();
+    let count = coll.revision_id().await;
+
+    let result = count.unwrap();
+    eprintln!("{:?}", result);
+    assert_eq!(result.revision, "0");
+    assert_eq!(result.name, collection_name);
+    assert_eq!(result.cache_enabled, false);
+    assert_eq!(result.is_system, false);
+    assert_eq!(result.wait_for_sync, false);
+    assert_eq!(result.key_options.allow_user_keys, true);
+    assert_eq!(result.key_options.r#type, Some("traditional".to_string()));
+    assert_eq!(result.key_options.last_value, Some(0));
+    assert_eq!(result.status, 3);
+    assert_eq!(result.write_concern, 1);
+
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+}

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -4,8 +4,9 @@
 use log::trace;
 use pretty_assertions::assert_eq;
 
-use arangors::{ClientError, Connection};
+use arangors::{ClientError, Connection, Document};
 use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup};
+use serde_json::Value;
 
 pub mod common;
 
@@ -102,6 +103,61 @@ async fn test_get_properties() {
     assert_eq!(result.key_options.last_value, Some(0));
     assert_eq!(result.status, 3);
     assert_eq!(result.write_concern, 1);
+
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+}
+
+#[maybe_async::test(
+    sync = r#"any(feature="reqwest_blocking")"#,
+    async = r#"any(feature="reqwest_async")"#,
+    test = "tokio::test"
+)]
+#[cfg_attr(feature = "surf_async", maybe_async::must_be_async, async_std::test)]
+async fn test_get_document_count() {
+    test_setup();
+    let host = get_arangodb_host();
+    let user = get_normal_user();
+    let password = get_normal_password();
+
+    let collection_name = "test_collection_count";
+
+    let conn = Connection::establish_jwt(&host, &user, &password)
+        .await
+        .unwrap();
+    let mut database = conn.db("test_db").await.unwrap();
+
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), true);
+
+    let coll = database.create_collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+
+    let coll = database.collection(collection_name).await;
+    assert_eq!(coll.is_err(), false);
+    let coll = coll.unwrap();
+    let count = coll.document_count().await;
+
+    let result = count.unwrap();
+    assert_eq!(result.count, Some(0));
+    assert_eq!(result.name, collection_name);
+    assert_eq!(result.cache_enabled, false);
+    assert_eq!(result.is_system, false);
+    assert_eq!(result.wait_for_sync, false);
+    assert_eq!(result.key_options.allow_user_keys, true);
+    assert_eq!(result.key_options.r#type, Some("traditional".to_string()));
+    assert_eq!(result.key_options.last_value, Some(0));
+    assert_eq!(result.status, 3);
+    assert_eq!(result.write_concern, 1);
+
+    let query: Vec<Value> = database
+        .aql_str(r#"INSERT {  "name": "test_user" } INTO test_collection_count"#)
+        .await
+        .unwrap();
+
+    let updated_count = coll.document_count().await;
+    let updated_result = updated_count.unwrap();
+    assert_eq!(updated_result.count, Some(1));
 
     let coll = database.drop_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);


### PR DESCRIPTION
Well, I guess that we need to implement all the methods we find on [Arangodb documentation](https://www.arangodb.com/docs/devel/http/collection-getting.html) for collection or maybe not.

Here is the todo list 
- [x] implement get_collection -> done previously in database::collection

- [x] update base_url for collection and add doc to it -> done in previous PR
- [x] implement collection::properties -> done in previous PR
- [x] add unit test for properties -> done in previous PR

- [x] add or update structures that match the information from the doc
Should we add `Option<T>` on CollectionDetails or having new structures?

- [x] implement document count
- [x] add unit test for get count

- [x]  implement statistics
- [x] add unit test for statistics

Should we do something about the shard stuff [there](https://www.arangodb.com/docs/devel/http/collection-getting.html#return-responsible-shard-for-a-document) and [there ](https://www.arangodb.com/docs/devel/http/collection-getting.html#return-the-shard-ids-of-a-collection) ?

- [x]  implement revision id 

Question : the response in Arangodb 3.7 and 3.6 are different for revision. What is the best way to handle that ?

- [x] add unit test for revision id

- [x] implement checksum for collection
- [x] add unit test for checksum for collection

Should we add [read all collections](https://www.arangodb.com/docs/devel/http/collection-getting.html#reads-all-collections) ?


