### PR TITLE
Add Working with a document

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1"
 thiserror = "1"
 url = "2"
 
-reqwest  = { version = "0.10", features = ["gzip", "json"], optional = true }
+reqwest  = { version = "0.10.4", features = ["gzip", "json"], optional = true }
 surf  = { version = "2.0.0-alpha.4", optional = true }
 http-types  = { version = "2.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,16 @@ log = "0.4"
 maybe-async = "0.2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_qs = "0.6.1"
 thiserror = "1"
+typed-builder = "0.6.0"
 url = "2"
+
 
 reqwest  = { version = "0.10.4", features = ["gzip", "json"], optional = true }
 surf  = { version = "2.0.0-alpha.4", optional = true }
 http-types  = { version = "2.2", optional = true }
+
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -17,10 +17,8 @@ use http::{HeaderMap, Method};
 use reqwest::Client;
 use url::Url;
 
-use arangors::{
-    client::{ClientExt, ClientResponse},
-    ClientError, GenericConnection,
-};
+use arangors::{client::ClientExt, ClientError, GenericConnection};
+use std::convert::TryInto;
 
 /// when use async http client, `blocking` feature MUST be disabled
 // This cfg is only to make rust compiler happy, you can just ignore it
@@ -38,24 +36,6 @@ pub struct ReqwestClient(pub Client);
 #[cfg(feature = "reqwest_async")]
 #[async_trait::async_trait]
 impl ClientExt for ReqwestClient {
-    async fn request(&self, request: http::Request<String>) -> Result<ClientResponse, ClientError> {
-        let resp = self
-            .0
-            .execute(request.into())
-            .await
-            .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))?;
-
-        let status_code = resp.status();
-        let headers = resp.headers().clone();
-        let version = Some(resp.version());
-        let content = resp
-            .text()
-            .await
-            .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))?;
-
-        Ok(ClientResponse::new(status_code, headers, content, version))
-    }
-
     fn new<U: Into<Option<HeaderMap>>>(headers: U) -> Result<Self, ClientError> {
         match headers.into() {
             Some(h) => Client::builder().default_headers(h),
@@ -64,6 +44,37 @@ impl ClientExt for ReqwestClient {
         .build()
         .map(|c| ReqwestClient(c))
         .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))
+    }
+
+    async fn request(
+        &self,
+        request: http::Request<String>,
+    ) -> Result<http::Response<String>, ClientError> {
+        let req = request.try_into().unwrap();
+
+        let resp = self
+            .0
+            .execute(req)
+            .await
+            .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))?;
+        let status_code = resp.status();
+        let headers = resp.headers().clone();
+        let version = resp.version();
+        let content = resp
+            .text()
+            .await
+            .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))?;
+        let mut build = http::Response::builder();
+
+        for header in headers.iter() {
+            build = build.header(header.0, header.1);
+        }
+
+        http::response::Builder::from(build)
+            .status(status_code)
+            .version(version)
+            .body(content)
+            .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
-use http::{method::Method, HeaderMap, Request};
-use serde::de::DeserializeOwned;
+use http::{method::Method, HeaderMap, Request, Response};
 use url::Url;
 
 use crate::ClientError;
@@ -39,7 +38,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         Self: Sized;
 
     #[inline]
-    async fn get(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn get(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -51,7 +50,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         .await
     }
     #[inline]
-    async fn post(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn post(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -63,7 +62,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         .await
     }
     #[inline]
-    async fn put(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn put(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -75,7 +74,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         .await
     }
     #[inline]
-    async fn delete(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn delete(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -87,7 +86,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         .await
     }
     #[inline]
-    async fn patch(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn patch(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -100,7 +99,7 @@ pub trait ClientExt: Sync + Debug + Clone {
     }
 
     #[inline]
-    async fn connect(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn connect(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -113,7 +112,7 @@ pub trait ClientExt: Sync + Debug + Clone {
     }
 
     #[inline]
-    async fn head(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn head(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -126,7 +125,7 @@ pub trait ClientExt: Sync + Debug + Clone {
     }
 
     #[inline]
-    async fn options(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn options(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -139,7 +138,7 @@ pub trait ClientExt: Sync + Debug + Clone {
     }
 
     #[inline]
-    async fn trace(&self, url: Url, text: &str) -> Result<ClientResponse, ClientError>
+    async fn trace(&self, url: Url, text: &str) -> Result<Response<String>, ClientError>
     where
         Self: Sized,
     {
@@ -151,68 +150,7 @@ pub trait ClientExt: Sync + Debug + Clone {
         .await
     }
 
-    // #[inline]
-    // fn build_request(&self, method: Method, url: Url, text: &str) -> ClientRequestBuilder<Self>
-    // where
-    //     Self: Sized,
-    // {
-    //     ClientRequestBuilder::new(self.clone(), method, url, text)
-    // }
-    async fn request(&self, request: Request<String>) -> Result<ClientResponse, ClientError>
+    async fn request(&self, request: Request<String>) -> Result<Response<String>, ClientError>
     where
         Self: Sized;
-}
-
-#[derive(Debug)]
-pub struct ClientResponse {
-    status_code: http::StatusCode,
-    headers: http::HeaderMap,
-    content: String,
-    version: Option<http::Version>,
-}
-
-impl ClientResponse {
-    pub fn new(
-        status_code: http::StatusCode,
-        headers: http::HeaderMap,
-        content: String,
-        version: Option<http::Version>,
-    ) -> Self {
-        Self {
-            status_code,
-            headers,
-            content,
-            version,
-        }
-    }
-
-    /// Get the `StatusCode` of this `Response`.
-    #[inline]
-    pub fn status(&self) -> http::StatusCode {
-        self.status_code
-    }
-
-    /// Get the HTTP `Version` of this `Response`.
-    #[inline]
-    pub fn version(&self) -> Option<http::Version> {
-        self.version
-    }
-
-    /// Get the `Headers` of this `Response`.
-    #[inline]
-    pub fn headers(&self) -> &HeaderMap {
-        &self.headers
-    }
-
-    /// Get response content in `String`
-    #[inline]
-    pub fn text(&self) -> &str {
-        &self.content
-    }
-
-    /// Get response content in `Json`
-    #[inline]
-    pub fn json<T: DeserializeOwned>(&self) -> Result<T, ClientError> {
-        Ok(serde_json::from_str(self.text())?)
-    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use http::{method::Method, HeaderMap, Request, Response};
+use http::{HeaderMap, Request, Response};
 use url::Url;
 
 use crate::ClientError;

--- a/src/client/reqwest.rs
+++ b/src/client/reqwest.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::client::ClientExt;
 
 use super::*;
-use std::convert::TryFrom;
+use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub struct ReqwestClient(pub Client);
@@ -28,7 +28,7 @@ impl ClientExt for ReqwestClient {
     }
 
     async fn request(&self, request: http::Request<String>) -> Result<ClientResponse, ClientError> {
-        let req: Request = request.into();
+        let req: Request = request.try_into().unwrap();
 
         let resp = self
             .0

--- a/src/client/surf.rs
+++ b/src/client/surf.rs
@@ -70,7 +70,7 @@ impl ClientExt for SurfClient {
             .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))?;
 
         let status_code = resp.status();
-
+        let status = u16::from(status_code);
         let mut headers = HeaderMap::new();
         let conv_header = |hn: HeaderName| -> HeaderValue {
             let v = resp
@@ -105,10 +105,12 @@ impl ClientExt for SurfClient {
             _ => unreachable!(),
         });
 
-        http::response::Builder::from(build)
-            .status(StatusCode::from_u16(u16::from(status_code)).unwrap())
-            .version(http_version.unwrap())
-            .body(content)
+        let mut resp =
+            http::response::Builder::from(build).status(StatusCode::from_u16(status).unwrap());
+        if version.is_some() {
+            resp = resp.version(http_version.unwrap());
+        }
+        resp.body(content)
             .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))
     }
 }

--- a/src/client/surf.rs
+++ b/src/client/surf.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, SERVER},
-    StatusCode, Version,
+    Method, StatusCode, Version,
 };
 use url::Url;
 

--- a/src/client/surf.rs
+++ b/src/client/surf.rs
@@ -106,7 +106,7 @@ impl ClientExt for SurfClient {
         });
 
         http::response::Builder::from(build)
-            .status(status_code)
+            .status(StatusCode::from_u16(u16::from(status_code)).unwrap())
             .version(http_version.unwrap())
             .body(content)
             .map_err(|e| ClientError::HttpClient(format!("{:?}", e)))

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -613,32 +613,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     {
         let mut url = self.document_base_url.join(_key).unwrap();
         let body = serde_json::to_string(&doc)?;
-        if let Some(options) = update_options {
-            if let Some(keep_null) = options.borrow().keep_null {
-                url.query_pairs_mut()
-                    .append_pair("keep_null", keep_null.to_string().as_str());
-            }
-            if let Some(return_new) = options.borrow().return_new {
-                url.query_pairs_mut()
-                    .append_pair("returnNew", return_new.to_string().as_str());
-            }
-            if let Some(wait_for_sync) = options.borrow().wait_for_sync {
-                url.query_pairs_mut()
-                    .append_pair("waitForSync", wait_for_sync.to_string().as_str());
-            }
-            if let Some(ignore_revs) = options.borrow().ignore_revs {
-                url.query_pairs_mut()
-                    .append_pair("ignoreRevs", ignore_revs.to_string().as_str());
-            }
-            if let Some(return_old) = options.borrow().return_old {
-                url.query_pairs_mut()
-                    .append_pair("returnOld", return_old.to_string().as_str());
-            }
-            if let Some(silent) = options.borrow().silent {
-                url.query_pairs_mut()
-                    .append_pair("silent", silent.to_string().as_str());
-            }
-        }
+        let query = qs::to_string(&update_options).unwrap();
+        url.set_query(Some(query.as_str()));
 
         let resp: DocumentResponse<T> =
             deserialize_response(self.session.patch(url, body.as_str()).await?.body())?;

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -578,23 +578,23 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// identifier, _key containing key which uniquely identifies a document in
     /// a given collection and _rev containing the revision.
     #[maybe_async]
-    pub async fn read_document<T>(&self, key: &str) -> Result<Document<T>, ClientError>
+    pub async fn read_document<T>(&self, _key: &str) -> Result<Document<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.read_document_with_options(key, None).await
+        self.read_document_with_options(_key, None).await
     }
 
     #[maybe_async]
     pub async fn read_document_with_options<T>(
         &self,
-        key: &str,
+        _key: &str,
         read_options: Option<DocumentReadOptions>,
     ) -> Result<Document<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let url = self.document_base_url.join(key).unwrap();
+        let url = self.document_base_url.join(_key).unwrap();
         let mut build = Request::get(url.to_string());
 
         let header = make_header_from_options(read_options);
@@ -611,18 +611,18 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// use this call to get the current revision of a document or check if the
     /// document was deleted.
     #[maybe_async]
-    pub async fn read_document_header(&self, key: &str) -> Result<DocumentHeader, ClientError> {
-        self.read_document_header_with_options(key, None).await
+    pub async fn read_document_header(&self, _key: &str) -> Result<DocumentHeader, ClientError> {
+        self.read_document_header_with_options(_key, None).await
     }
 
     #[maybe_async]
     pub async fn read_document_header_with_options(
         &self,
-        key: &str,
+        _key: &str,
         read_options: Option<DocumentReadOptions>,
     ) -> Result<DocumentHeader, ClientError>
 where {
-        let url = self.document_base_url.join(key).unwrap();
+        let url = self.document_base_url.join(_key).unwrap();
         let mut build = Request::get(url.to_string());
 
         let header = make_header_from_options(read_options);
@@ -637,14 +637,14 @@ where {
     #[maybe_async]
     pub async fn update_document<T>(
         &self,
-        key: &str,
+        _key: &str,
         doc: T,
         update_options: Option<DocumentUpdateOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(key).unwrap();
+        let mut url = self.document_base_url.join(_key).unwrap();
         let body = serde_json::to_string(&doc)?;
         if let Some(options) = update_options {
             if let Some(keep_null) = options.borrow().keep_null {
@@ -722,14 +722,14 @@ where {
     #[maybe_async]
     pub async fn replace_document<T>(
         &self,
-        key: &str,
+        _key: &str,
         doc: T,
         update_options: Option<DocumentReplaceOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(key).unwrap();
+        let mut url = self.document_base_url.join(_key).unwrap();
         let body = serde_json::to_string(&doc)?;
         let mut header = ("".to_string(), "".to_string());
 
@@ -787,13 +787,13 @@ where {
     #[maybe_async]
     pub async fn remove_document<T>(
         &self,
-        key: &str,
+        _key: &str,
         remove_options: Option<DocumentRemoveOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(key).unwrap();
+        let mut url = self.document_base_url.join(_key).unwrap();
         let mut header = ("".to_string(), "".to_string());
 
         if let Some(options) = remove_options {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -668,7 +668,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         &self,
         _key: &str,
         doc: T,
-        replace_options: Option<DocumentReplaceOptions>,
+        replace_options: DocumentReplaceOptions,
         if_match_header: Option<String>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -22,7 +22,6 @@ use crate::document::{
 };
 use http::Request;
 use serde::de::DeserializeOwned;
-use std::borrow::Borrow;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -640,7 +640,7 @@ where {
             }
             if let Some(ignore_revs) = options.borrow().ignore_revs {
                 url.query_pairs_mut()
-                    .append_pair("ignore_revs", ignore_revs.to_string().as_str());
+                    .append_pair("ignoreRevs", ignore_revs.to_string().as_str());
             }
             if let Some(return_old) = options.borrow().return_old {
                 url.query_pairs_mut()

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -9,9 +9,11 @@ use url::Url;
 
 use maybe_async::maybe_async;
 
-use crate::client::ClientExt;
-use crate::response::ArangoResult;
-use crate::{response::deserialize_response, ClientError};
+use crate::{
+    client::ClientExt,
+    response::{deserialize_response, ArangoResult},
+    ClientError,
+};
 
 use super::{Database, Document};
 use crate::document::{
@@ -20,8 +22,7 @@ use crate::document::{
 };
 use http::Request;
 use serde::de::DeserializeOwned;
-use std::borrow::Borrow;
-use std::fmt::Debug;
+use std::{borrow::Borrow, fmt::Debug};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -116,11 +117,12 @@ pub struct CollectionChecksum {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionPropertiesOptions {
-    /// If true then creating or changing a document will wait until the data has been synchronized to disk.
+    /// If true then creating or changing a document will wait until the data
+    /// has been synchronized to disk.
     pub wait_for_sync: Option<bool>,
-    // for ArangoDb 3.7
-    // TODO need to implement this with feature gate between versions maybe
-    // pub schema: Option<SchemaRules>,
+    /* for ArangoDb 3.7
+     * TODO need to implement this with feature gate between versions maybe
+     * pub schema: Option<SchemaRules>, */
 }
 
 #[derive(Debug, Deserialize)]
@@ -217,7 +219,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     }
 
     /// Fetch the properties of collection
-    ///
     #[maybe_async]
     pub async fn properties(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("properties").unwrap();
@@ -227,7 +228,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     }
 
     /// Counts the documents in this collection
-    ///
     #[maybe_async]
     pub async fn document_count(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("count").unwrap();
@@ -260,7 +260,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// collection is normally slightly higher than the sum of the reported
     /// fileSize values. Still the sum of the fileSize values can still be used
     /// as a lower bound approximation of the disk usage.
-    ///
     #[maybe_async]
     pub async fn statistics(&self) -> Result<CollectionStatistics, ClientError> {
         let url = self.base_url.join("figures").unwrap();
@@ -274,7 +273,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// The revision id is a server-generated string that clients can use to
     /// check whether data in a collection has changed since the last revision
     /// check.
-    ///
     #[maybe_async]
     pub async fn revision_id(&self) -> Result<CollectionRevision, ClientError> {
         let url = self.base_url.join("revision").unwrap();
@@ -286,34 +284,38 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     ///
     /// Will calculate a checksum of the meta-data (keys and optionally
     /// revision ids) and optionally the document data in the collection.
-    /// The checksum can be used to compare if two collections on different ArangoDB
-    /// instances contain the same contents. The current revision of the collection
-    /// is returned too so one can make sure the checksums are calculated for the
-    /// same state of data.
+    /// The checksum can be used to compare if two collections on different
+    /// ArangoDB instances contain the same contents. The current revision
+    /// of the collection is returned too so one can make sure the checksums
+    /// are calculated for the same state of data.
     ///
     /// By default, the checksum will only be calculated on the _key system
     /// attribute of the documents contained in the collection. For edge
-    /// collections, the system attributes _from and _to will also be included in
-    /// the calculation.
+    /// collections, the system attributes _from and _to will also be included
+    /// in the calculation.
     ///
-    /// By setting the optional query parameter withRevisions to true, then revision
-    /// ids (_rev system attributes) are included in the checksumming.
+    /// By setting the optional query parameter withRevisions to true, then
+    /// revision ids (_rev system attributes) are included in the
+    /// checksumming.
     ///
-    /// By providing the optional query parameter withData with a value of true, the
-    /// user-defined document attributes will be included in the calculation too.
-    /// Note: Including user-defined attributes will make the checksumming slower.
-    /// this function would make a request to arango server.
+    /// By providing the optional query parameter withData with a value of true,
+    /// the user-defined document attributes will be included in the
+    /// calculation too. Note: Including user-defined attributes will make
+    /// the checksumming slower. this function would make a request to
+    /// arango server.
     #[maybe_async]
     pub async fn checksum(&self) -> Result<CollectionChecksum, ClientError> {
         self.checksum_with_options(false, false).await
     }
 
-    /// By setting the optional query parameter withRevisions to true, then revision
-    /// ids (_rev system attributes) are included in the checksumming.
+    /// By setting the optional query parameter withRevisions to true, then
+    /// revision ids (_rev system attributes) are included in the
+    /// checksumming.
     ///
-    /// By providing the optional query parameter withData with a value of true, the
-    /// user-defined document attributes will be included in the calculation too.
-    /// Note: Including user-defined attributes will make the checksumming slower.
+    /// By providing the optional query parameter withData with a value of true,
+    /// the user-defined document attributes will be included in the
+    /// calculation too. Note: Including user-defined attributes will make
+    /// the checksumming slower.
     #[maybe_async]
     pub async fn checksum_with_options(
         &self,
@@ -336,9 +338,12 @@ impl<'a, C: ClientExt> Collection<'a, C> {
 
     /// Loads a collection into memory. Returns the collection on success.
     ///
-    /// The request body object might optionally contain the following attribute:
-    /// - count: If set, this controls whether the return value should include the number of documents in the collection.
-    /// Setting count to false may speed up loading a collection. The default value for count is true.
+    /// The request body object might optionally contain the following
+    /// attribute:
+    /// - count: If set, this controls whether the return value should include
+    ///   the number of documents in the collection.
+    /// Setting count to false may speed up loading a collection. The default
+    /// value for count is true.
     #[maybe_async]
     pub async fn load(&self, count: bool) -> Result<CollectionInfo, ClientError> {
         let url = self.base_url.join("load").unwrap();
@@ -446,7 +451,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// journal file automatically if there is no current journal.
     ///
     /// This methods is not documented on 3.7
-    /// Note: this method is specific for the MMFiles storage engine, and there it is not available in a cluster.
+    /// Note: this method is specific for the MMFiles storage engine, and there
+    /// it is not available in a cluster.
     #[cfg(feature = "mmfiles")]
     #[maybe_async]
     pub async fn rotate_journal(&self) -> Result<bool, ClientError> {
@@ -462,28 +468,35 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// Possibly given _id and _rev attributes in the body are always ignored,
     /// the URL part or the query parameter collection respectively counts.
     ///
-    /// If the document was created successfully, then the Location header contains
-    /// the path to the newly created document.
+    /// If the document was created successfully, then the Location header
+    /// contains the path to the newly created document.
     /// The Etag header field contains the revision of the document.
     /// Both are only set in the single document case.
     ///
-    /// If silent is not set to true, the body of the response contains a JSON object with the following attributes:
+    /// If silent is not set to true, the body of the response contains a JSON
+    /// object with the following attributes:
     ///
     /// _id contains the document identifier of the newly created document
     /// _key contains the document key
     /// _rev contains the document revision
-    /// If the collection parameter waitForSync is false, then the call returns as soon as the document has been accepted.
-    /// It will not wait until the documents have been synced to disk.
+    /// If the collection parameter waitForSync is false, then the call returns
+    /// as soon as the document has been accepted. It will not wait until
+    /// the documents have been synced to disk.
     ///
-    /// Optionally, the query parameter waitForSync can be used to force synchronization of the document creation
-    /// operation to disk even in case that the waitForSync flag had been disabled for the entire collection.
-    /// Thus, the waitForSync query parameter can be used to force synchronization of just this specific operations.
-    /// To use this, set the waitForSync parameter to true. If the waitForSync parameter is not specified or set to false,
-    /// then the collection’s default waitForSync behavior is applied.
-    /// The waitForSync query parameter cannot be used to disable synchronization for collections that have a default waitForSync value of true.
+    /// Optionally, the query parameter waitForSync can be used to force
+    /// synchronization of the document creation operation to disk even in
+    /// case that the waitForSync flag had been disabled for the entire
+    /// collection. Thus, the waitForSync query parameter can be used to
+    /// force synchronization of just this specific operations. To use this,
+    /// set the waitForSync parameter to true. If the waitForSync parameter is
+    /// not specified or set to false, then the collection’s default
+    /// waitForSync behavior is applied. The waitForSync query parameter
+    /// cannot be used to disable synchronization for collections that have a
+    /// default waitForSync value of true.
     ///
-    /// If the query parameter returnNew is true, then, for each generated document, the complete new document is returned under the new attribute in the result.
-    /// # Note
+    /// If the query parameter returnNew is true, then, for each generated
+    /// document, the complete new document is returned under the new attribute
+    /// in the result. # Note
     /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn create_document<T>(
@@ -569,8 +582,9 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     }
 
     /// Reads a single document header
-    /// Like GET, but only returns the header fields and not the body. You can use this call to get the current revision of a document or check if the document was deleted.
-    /// # Note
+    /// Like GET, but only returns the header fields and not the body. You can
+    /// use this call to get the current revision of a document or check if the
+    /// document was deleted. # Note
     /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn read_document_header(&self, _key: &str) -> Result<DocumentHeader, ClientError> {
@@ -644,6 +658,8 @@ where {
     }
 
     /// Replaces the document
+    /// Replaces the specified document with the one in the body, provided there
+    /// is such a document and no precondition is violated.
     ///
     /// # Note
     /// this function would make a request to arango server.
@@ -727,6 +743,7 @@ impl<'de> Deserialize<'de> for CollectionType {
         }
     }
 }
+
 /// Create header name and header value from read_options
 fn make_header_from_options(
     document_read_options: Option<DocumentReadOptions>,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -706,39 +706,26 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     //
     // If the query parameter returnOld is true, then the complete previous revision of the document
     // is returned under the old attribute in the result.
+    /// You can conditionally replace a document based on a target revision id
+    /// by using the if-match HTTP header.
     #[maybe_async]
     pub async fn remove_document<T>(
         &self,
         _key: &str,
         remove_options: Option<DocumentRemoveOptions>,
+        if_match_header: Option<String>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
         let mut url = self.document_base_url.join(_key).unwrap();
-        let mut header = ("".to_string(), "".to_string());
+        let query = qs::to_string(&remove_options).unwrap();
+        url.set_query(Some(query.as_str()));
 
-        if let Some(options) = remove_options {
-            if let Some(wait_for_sync) = options.wait_for_sync {
-                url.query_pairs_mut()
-                    .append_pair("waitForSync", wait_for_sync.to_string().as_str());
-            }
-            if let Some(return_old) = options.return_old {
-                url.query_pairs_mut()
-                    .append_pair("returnOld", return_old.to_string().as_str());
-            }
-            if let Some(silent) = options.silent {
-                url.query_pairs_mut()
-                    .append_pair("silent", silent.to_string().as_str());
-            }
-            if let Some(if_match) = options.if_match {
-                header = ("If-Match".to_string(), if_match);
-            }
-        }
         let mut build = Request::delete(url.to_string());
 
-        if (header.0 != "") & (header.1 != "") {
-            build = build.header(header.0.as_str(), header.1.as_str());
+        if let Some(if_match_value) = if_match_header {
+            build = build.header("If-Match", if_match_value);
         }
 
         let req = build.body("".to_string()).unwrap();

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -455,7 +455,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         Ok(resp)
     }
 
-    /// recalculates the document count of a collection
+    /// Recalculates the document count of a collection
     /// Note: this method is specific for the RocksDB storage engine
     #[cfg(feature = "rocksdb")]
     #[maybe_async]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{Database, Document};
 use crate::document::{
     DocumentHeader, DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions,
-    DocumentReplaceOptions, DocumentResponse, DocumentUpdateOptions,
+    DocumentRemoveOptions, DocumentReplaceOptions, DocumentResponse, DocumentUpdateOptions,
 };
 use http::Request;
 use serde::de::DeserializeOwned;
@@ -755,8 +755,45 @@ where {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn remove_document<T>(&self, doc: Document<T>) {
-        unimplemented!()
+    pub async fn remove_document<T>(
+        &self,
+        _key: &str,
+        remove_options: Option<DocumentRemoveOptions>,
+    ) -> Result<DocumentResponse<T>, ClientError>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        let mut url = self.document_base_url.join(_key).unwrap();
+        let mut header = ("".to_string(), "".to_string());
+
+        if let Some(options) = remove_options {
+            if let Some(wait_for_sync) = options.wait_for_sync {
+                url.query_pairs_mut()
+                    .append_pair("waitForSync", wait_for_sync.to_string().as_str());
+            }
+            if let Some(return_old) = options.return_old {
+                url.query_pairs_mut()
+                    .append_pair("returnOld", return_old.to_string().as_str());
+            }
+            if let Some(silent) = options.silent {
+                url.query_pairs_mut()
+                    .append_pair("silent", silent.to_string().as_str());
+            }
+            if let Some(if_match) = options.if_match {
+                header = ("If-Match".to_string(), if_match);
+            }
+        }
+        let mut build = Request::delete(url.to_string());
+
+        if (header.0 != "") & (header.1 != "") {
+            build = build.header(header.0.as_str(), header.1.as_str());
+        }
+
+        let req = build.body("".to_string()).unwrap();
+
+        let resp: DocumentResponse<T> =
+            deserialize_response(self.session.request(req).await?.body())?;
+        Ok(resp)
     }
 }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -620,8 +620,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         &self,
         _key: &str,
         read_options: Option<DocumentReadOptions>,
-    ) -> Result<DocumentHeader, ClientError>
-where {
+    ) -> Result<DocumentHeader, ClientError> {
         let url = self.document_base_url.join(_key).unwrap();
         let mut build = Request::get(url.to_string());
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -533,40 +533,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     {
         let mut url = self.document_base_url.join("").unwrap();
         let body = serde_json::to_string(&doc)?;
-
-        if let Some(options) = insert_options {
-            if let Some(return_new) = options.borrow().return_new {
-                url.query_pairs_mut()
-                    .append_pair("returnNew", return_new.to_string().as_str());
-            }
-            if let Some(wait_for_sync) = options.borrow().wait_for_sync {
-                url.query_pairs_mut()
-                    .append_pair("waitForSync", wait_for_sync.to_string().as_str());
-            }
-            if let Some(return_old) = options.borrow().return_old {
-                url.query_pairs_mut()
-                    .append_pair("returnOld", return_old.to_string().as_str());
-            }
-            if let Some(silent) = options.borrow().silent {
-                url.query_pairs_mut()
-                    .append_pair("silent", silent.to_string().as_str());
-            }
-            if let Some(overwrite) = options.borrow().overwrite {
-                url.query_pairs_mut()
-                    .append_pair("overwrite", overwrite.to_string().as_str());
-            }
-            #[cfg(feature = "arango3_7")]
-            if let Some(overwrite_mode) = options.overwrite_mode {
-                let mode = match overwrite_mode {
-                    DocumentOverwriteMode::Ignore => "ignore",
-                    DocumentOverwriteMode::Replace => "replace",
-                    DocumentOverwriteMode::Update => "update",
-                    DocumentOverwriteMode::Conflict => "conflict",
-                };
-                url.query_pairs_mut().append_pair("overwriteMode", mode);
-            }
-        }
-
+        let query = qs::to_string(&insert_options).unwrap();
+        url.set_query(Some(query.as_str()));
         let resp: DocumentResponse<T> =
             deserialize_response(self.session.post(url, body.as_str()).await?.body())?;
         Ok(resp)

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -605,7 +605,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         &self,
         _key: &str,
         doc: T,
-        update_options: Option<DocumentUpdateOptions>,
+        update_options: DocumentUpdateOptions,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -826,7 +826,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct CollectionResponse {
     pub id: String,
     pub name: String,
@@ -838,7 +838,7 @@ pub struct CollectionResponse {
     pub global_unique_id: String,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum CollectionStatus {
     NewBorn = 1,
     Unloaded = 2,
@@ -869,7 +869,7 @@ impl<'de> Deserialize<'de> for CollectionStatus {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum CollectionType {
     Document = 2,
     Edge = 3,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -222,7 +222,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn properties(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("properties").unwrap();
         let resp: CollectionProperties =
-            serialize_response(self.session.get(url, "").await?.text())?;
+            serialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -232,7 +232,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn document_count(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("count").unwrap();
         let resp: CollectionProperties =
-            serialize_response(self.session.get(url, "").await?.text())?;
+            serialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
     /// Fetch the statistics of a collection
@@ -265,7 +265,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn statistics(&self) -> Result<CollectionStatistics, ClientError> {
         let url = self.base_url.join("figures").unwrap();
         let resp: CollectionStatistics =
-            serialize_response(self.session.get(url, "").await?.text())?;
+            serialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -278,7 +278,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn revision_id(&self) -> Result<CollectionRevision, ClientError> {
         let url = self.base_url.join("revision").unwrap();
-        let resp: CollectionRevision = serialize_response(self.session.get(url, "").await?.text())?;
+        let resp: CollectionRevision = serialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
     /// Fetch a checksum for the specified collection
@@ -328,7 +328,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             url.query_pairs_mut().append_pair("withData", "true");
         }
 
-        let resp: CollectionChecksum = serialize_response(self.session.get(url, "").await?.text())?;
+        let resp: CollectionChecksum = serialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -345,7 +345,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
-                .text(),
+                .body(),
         )?;
         Ok(resp)
     }
@@ -356,7 +356,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn unload(&self) -> Result<CollectionInfo, ClientError> {
         let url = self.base_url.join("unload").unwrap();
-        let resp: CollectionInfo = serialize_response(self.session.put(url, "").await?.text())?;
+        let resp: CollectionInfo = serialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -384,7 +384,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn load_indexes(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("loadIndexesIntoMemory").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.text())?;
+        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
 
@@ -403,7 +403,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
-                .text(),
+                .body(),
         )?;
         Ok(resp)
     }
@@ -417,7 +417,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
-                .text(),
+                .body(),
         )?;
         Ok(resp)
     }
@@ -428,7 +428,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn recalculate_count(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("recalculateCount").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.text())?;
+        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
     /// Rotates the journal of a collection.
@@ -447,7 +447,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn rotate_journal(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("rotate").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.text())?;
+        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
 
@@ -526,7 +526,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let resp: DocumentResponse<T> =
-            serde_json::from_str(self.session.post(url, body.as_str()).await?.text())?;
+            serde_json::from_str(self.session.post(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 
@@ -565,7 +565,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: Document<T> = serde_json::from_str(self.session.request(req).await?.text())?;
+        let resp: Document<T> = serde_json::from_str(self.session.request(req).await?.body())?;
         Ok(resp)
     }
 
@@ -599,7 +599,7 @@ where {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: DocumentHeader = serde_json::from_str(self.session.request(req).await?.text())?;
+        let resp: DocumentHeader = serde_json::from_str(self.session.request(req).await?.body())?;
         Ok(resp)
     }
     /// Partially updates the document
@@ -646,7 +646,7 @@ where {
         }
 
         let resp: DocumentResponse<T> =
-            serde_json::from_str(self.session.patch(url, body.as_str()).await?.text())?;
+            serde_json::from_str(self.session.patch(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -578,23 +578,23 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// identifier, _key containing key which uniquely identifies a document in
     /// a given collection and _rev containing the revision.
     #[maybe_async]
-    pub async fn read_document<T>(&self, _key: &str) -> Result<Document<T>, ClientError>
+    pub async fn read_document<T>(&self, key: &str) -> Result<Document<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        self.read_document_with_options(_key, None).await
+        self.read_document_with_options(key, None).await
     }
 
     #[maybe_async]
     pub async fn read_document_with_options<T>(
         &self,
-        _key: &str,
+        key: &str,
         read_options: Option<DocumentReadOptions>,
     ) -> Result<Document<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let url = self.document_base_url.join(_key).unwrap();
+        let url = self.document_base_url.join(key).unwrap();
         let mut build = Request::get(url.to_string());
 
         let header = make_header_from_options(read_options);
@@ -611,18 +611,18 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// use this call to get the current revision of a document or check if the
     /// document was deleted.
     #[maybe_async]
-    pub async fn read_document_header(&self, _key: &str) -> Result<DocumentHeader, ClientError> {
-        self.read_document_header_with_options(_key, None).await
+    pub async fn read_document_header(&self, key: &str) -> Result<DocumentHeader, ClientError> {
+        self.read_document_header_with_options(key, None).await
     }
 
     #[maybe_async]
     pub async fn read_document_header_with_options(
         &self,
-        _key: &str,
+        key: &str,
         read_options: Option<DocumentReadOptions>,
     ) -> Result<DocumentHeader, ClientError>
 where {
-        let url = self.document_base_url.join(_key).unwrap();
+        let url = self.document_base_url.join(key).unwrap();
         let mut build = Request::get(url.to_string());
 
         let header = make_header_from_options(read_options);
@@ -637,14 +637,14 @@ where {
     #[maybe_async]
     pub async fn update_document<T>(
         &self,
-        _key: &str,
+        key: &str,
         doc: T,
         update_options: Option<DocumentUpdateOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(_key).unwrap();
+        let mut url = self.document_base_url.join(key).unwrap();
         let body = serde_json::to_string(&doc)?;
         if let Some(options) = update_options {
             if let Some(keep_null) = options.borrow().keep_null {
@@ -722,14 +722,14 @@ where {
     #[maybe_async]
     pub async fn replace_document<T>(
         &self,
-        _key: &str,
+        key: &str,
         doc: T,
         update_options: Option<DocumentReplaceOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(_key).unwrap();
+        let mut url = self.document_base_url.join(key).unwrap();
         let body = serde_json::to_string(&doc)?;
         let mut header = ("".to_string(), "".to_string());
 
@@ -787,13 +787,13 @@ where {
     #[maybe_async]
     pub async fn remove_document<T>(
         &self,
-        _key: &str,
+        key: &str,
         remove_options: Option<DocumentRemoveOptions>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,
     {
-        let mut url = self.document_base_url.join(_key).unwrap();
+        let mut url = self.document_base_url.join(key).unwrap();
         let mut header = ("".to_string(), "".to_string());
 
         if let Some(options) = remove_options {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -682,8 +682,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
 
         let mut build = Request::put(url.to_string());
 
-        if let Some(if_match) = if_match_header {
-            build = build.header("If-Match", if_match);
+        if let Some(if_match_value) = if_match_header {
+            build = build.header("If-Match", if_match_value);
         }
 
         let req = build.body(body).unwrap();

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -711,7 +711,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn remove_document<T>(
         &self,
         _key: &str,
-        remove_options: Option<DocumentRemoveOptions>,
+        remove_options: DocumentRemoveOptions,
         if_match_header: Option<String>,
     ) -> Result<DocumentResponse<T>, ClientError>
     where

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -662,6 +662,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// new document is returned under the new attribute in the result.
     /// If the document does not exist, then a HTTP 404 is returned and the body
     /// of the response contains an error document.
+    /// You can conditionally replace a document based on a target revision id
+    /// by using the if-match HTTP header.
     #[maybe_async]
     pub async fn replace_document<T>(
         &self,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -18,7 +18,7 @@ use crate::document::{
     DocumentHeader, DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions,
     DocumentResponse, DocumentUpdateOptions,
 };
-use http::{Method, Request};
+use http::Request;
 use serde::de::DeserializeOwned;
 use std::borrow::Borrow;
 use std::fmt::Debug;

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -212,8 +212,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
 
     /// Truncate current collection.
     ///
-    /// # Note
-    /// this function would make a request to arango server.
     pub fn truncate(&self) {
         unimplemented!()
     }
@@ -496,8 +494,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     ///
     /// If the query parameter returnNew is true, then, for each generated
     /// document, the complete new document is returned under the new attribute
-    /// in the result. # Note
-    /// this function would make a request to arango server.
+    /// in the result.
     #[maybe_async]
     pub async fn create_document<T>(
         &self,
@@ -550,8 +547,6 @@ impl<'a, C: ClientExt> Collection<'a, C> {
 
     /// Reads a single document
     ///
-    /// # Note
-    /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn read_document<T>(&self, _key: &str) -> Result<Document<T>, ClientError>
     where
@@ -584,8 +579,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     /// Reads a single document header
     /// Like GET, but only returns the header fields and not the body. You can
     /// use this call to get the current revision of a document or check if the
-    /// document was deleted. # Note
-    /// this function would make a request to arango server.
+    /// document was deleted.
     #[maybe_async]
     pub async fn read_document_header(&self, _key: &str) -> Result<DocumentHeader, ClientError> {
         self.read_document_header_with_options(_key, None).await
@@ -611,8 +605,6 @@ where {
     }
     /// Partially updates the document
     ///
-    /// # Note
-    /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn update_document<T>(
         &self,
@@ -752,8 +744,6 @@ where {
 
     /// Removes a document
     ///
-    /// # Note
-    /// this function would make a request to arango server.
     #[maybe_async]
     pub async fn remove_document<T>(
         &self,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -143,7 +143,7 @@ pub struct CollectionInfo {
 /// collection name, but not the collection identifier. Collections have a type
 /// that is specified by the user when the collection is created. There are
 /// currently two types: document and edge. The default type is document.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Collection<'a, C: ClientExt> {
     /// The collection identifier
     /// A collection identifier lets you refer to a collection in a database. It

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -526,7 +526,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let resp: DocumentResponse<T> =
-            serde_json::from_str(self.session.post(url, body.as_str()).await?.body())?;
+            serialize_response(self.session.post(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 
@@ -565,7 +565,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: Document<T> = serde_json::from_str(self.session.request(req).await?.body())?;
+        let resp: Document<T> = serialize_response(self.session.request(req).await?.body())?;
         Ok(resp)
     }
 
@@ -599,7 +599,7 @@ where {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: DocumentHeader = serde_json::from_str(self.session.request(req).await?.body())?;
+        let resp: DocumentHeader = serialize_response(self.session.request(req).await?.body())?;
         Ok(resp)
     }
     /// Partially updates the document
@@ -646,7 +646,7 @@ where {
         }
 
         let resp: DocumentResponse<T> =
-            serde_json::from_str(self.session.patch(url, body.as_str()).await?.body())?;
+            serialize_response(self.session.patch(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -525,7 +525,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn create_document<T>(
         &self,
         doc: T,
-        insert_options: Option<DocumentInsertOptions>,
+        insert_options: DocumentInsertOptions,
     ) -> Result<DocumentResponse<T>, ClientError>
     where
         T: Serialize + DeserializeOwned,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -22,9 +22,9 @@ use crate::document::{
 };
 use http::Request;
 use serde::de::DeserializeOwned;
-use std::{borrow::Borrow, fmt::Debug};
+use std::borrow::Borrow;
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionKeyOptions {
     pub allow_user_keys: bool,
@@ -34,7 +34,7 @@ pub struct CollectionKeyOptions {
     pub r#type: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionProperties {
     #[serde(flatten)]
@@ -43,7 +43,7 @@ pub struct CollectionProperties {
     pub detail: CollectionDetails,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionDetails {
     pub status_string: String,
@@ -64,20 +64,20 @@ pub struct CollectionDetails {
     pub index_buckets: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArangoIndex {
     pub count: Option<u32>,
     pub size: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Figures {
     pub indexes: ArangoIndex,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionStatistics {
     /// The number of documents currently present in the collection.
@@ -91,7 +91,7 @@ pub struct CollectionStatistics {
     pub detail: CollectionDetails,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionRevision {
     // pub uses_revisions_as_document_ids: Option<bool>,
@@ -105,7 +105,7 @@ pub struct CollectionRevision {
     pub detail: CollectionDetails,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionChecksum {
     pub revision: String,
@@ -114,7 +114,7 @@ pub struct CollectionChecksum {
     pub info: CollectionInfo,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionPropertiesOptions {
     /// If true then creating or changing a document will wait until the data
@@ -125,7 +125,7 @@ pub struct CollectionPropertiesOptions {
      * pub schema: Option<SchemaRules>, */
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionInfo {
     pub count: Option<u32>,
@@ -143,7 +143,7 @@ pub struct CollectionInfo {
 /// collection name, but not the collection identifier. Collections have a type
 /// that is specified by the user when the collection is created. There are
 /// currently two types: document and edge. The default type is document.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Collection<'a, C: ClientExt> {
     /// The collection identifier
     /// A collection identifier lets you refer to a collection in a database. It
@@ -580,7 +580,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn read_document<T>(&self, _key: &str) -> Result<Document<T>, ClientError>
     where
-        T: Serialize + Debug + DeserializeOwned,
+        T: Serialize + DeserializeOwned,
     {
         self.read_document_with_options(_key, None).await
     }
@@ -592,7 +592,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         read_options: Option<DocumentReadOptions>,
     ) -> Result<Document<T>, ClientError>
     where
-        T: Serialize + Debug + DeserializeOwned,
+        T: Serialize + DeserializeOwned,
     {
         let url = self.document_base_url.join(_key).unwrap();
         let mut build = Request::get(url.to_string());
@@ -827,7 +827,7 @@ where {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct CollectionResponse {
     pub id: String,
     pub name: String,
@@ -839,7 +839,7 @@ pub struct CollectionResponse {
     pub global_unique_id: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum CollectionStatus {
     NewBorn = 1,
     Unloaded = 2,
@@ -870,7 +870,7 @@ impl<'de> Deserialize<'de> for CollectionStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub enum CollectionType {
     Document = 2,
     Edge = 3,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -11,7 +11,7 @@ use maybe_async::maybe_async;
 
 use crate::client::ClientExt;
 use crate::response::ArangoResult;
-use crate::{response::serialize_response, ClientError};
+use crate::{response::deserialize_response, ClientError};
 
 use super::{Database, Document};
 use crate::document::{
@@ -222,7 +222,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn properties(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("properties").unwrap();
         let resp: CollectionProperties =
-            serialize_response(self.session.get(url, "").await?.body())?;
+            deserialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -232,7 +232,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn document_count(&self) -> Result<CollectionProperties, ClientError> {
         let url = self.base_url.join("count").unwrap();
         let resp: CollectionProperties =
-            serialize_response(self.session.get(url, "").await?.body())?;
+            deserialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
     /// Fetch the statistics of a collection
@@ -265,7 +265,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn statistics(&self) -> Result<CollectionStatistics, ClientError> {
         let url = self.base_url.join("figures").unwrap();
         let resp: CollectionStatistics =
-            serialize_response(self.session.get(url, "").await?.body())?;
+            deserialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -278,7 +278,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn revision_id(&self) -> Result<CollectionRevision, ClientError> {
         let url = self.base_url.join("revision").unwrap();
-        let resp: CollectionRevision = serialize_response(self.session.get(url, "").await?.body())?;
+        let resp: CollectionRevision =
+            deserialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
     /// Fetch a checksum for the specified collection
@@ -328,7 +329,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             url.query_pairs_mut().append_pair("withData", "true");
         }
 
-        let resp: CollectionChecksum = serialize_response(self.session.get(url, "").await?.body())?;
+        let resp: CollectionChecksum =
+            deserialize_response(self.session.get(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -341,7 +343,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn load(&self, count: bool) -> Result<CollectionInfo, ClientError> {
         let url = self.base_url.join("load").unwrap();
         let body = json!({ "count": count });
-        let resp: CollectionInfo = serialize_response(
+        let resp: CollectionInfo = deserialize_response(
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
@@ -356,7 +358,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn unload(&self) -> Result<CollectionInfo, ClientError> {
         let url = self.base_url.join("unload").unwrap();
-        let resp: CollectionInfo = serialize_response(self.session.put(url, "").await?.body())?;
+        let resp: CollectionInfo = deserialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp)
     }
 
@@ -384,7 +386,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn load_indexes(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("loadIndexesIntoMemory").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
+        let resp: ArangoResult<bool> =
+            deserialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
 
@@ -399,7 +402,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         if properties.wait_for_sync.is_some() {
             body["waitForSync"] = json!(properties.wait_for_sync.unwrap());
         }
-        let resp: CollectionProperties = serialize_response(
+        let resp: CollectionProperties = deserialize_response(
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
@@ -413,7 +416,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     pub async fn rename(&self, name: &str) -> Result<CollectionInfo, ClientError> {
         let url = self.base_url.join("rename").unwrap();
         let body = json!({ "name": name });
-        let resp: CollectionInfo = serialize_response(
+        let resp: CollectionInfo = deserialize_response(
             self.session
                 .put(url, body.to_string().as_str())
                 .await?
@@ -428,7 +431,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn recalculate_count(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("recalculateCount").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
+        let resp: ArangoResult<bool> =
+            deserialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
     /// Rotates the journal of a collection.
@@ -447,7 +451,8 @@ impl<'a, C: ClientExt> Collection<'a, C> {
     #[maybe_async]
     pub async fn rotate_journal(&self) -> Result<bool, ClientError> {
         let url = self.base_url.join("rotate").unwrap();
-        let resp: ArangoResult<bool> = serialize_response(self.session.put(url, "").await?.body())?;
+        let resp: ArangoResult<bool> =
+            deserialize_response(self.session.put(url, "").await?.body())?;
         Ok(resp.unwrap())
     }
 
@@ -526,7 +531,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let resp: DocumentResponse<T> =
-            serialize_response(self.session.post(url, body.as_str()).await?.body())?;
+            deserialize_response(self.session.post(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 
@@ -565,7 +570,7 @@ impl<'a, C: ClientExt> Collection<'a, C> {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: Document<T> = serialize_response(self.session.request(req).await?.body())?;
+        let resp: Document<T> = deserialize_response(self.session.request(req).await?.body())?;
         Ok(resp)
     }
 
@@ -599,7 +604,7 @@ where {
         }
 
         let req = build.body("".to_string()).unwrap();
-        let resp: DocumentHeader = serialize_response(self.session.request(req).await?.body())?;
+        let resp: DocumentHeader = deserialize_response(self.session.request(req).await?.body())?;
         Ok(resp)
     }
     /// Partially updates the document
@@ -646,7 +651,7 @@ where {
         }
 
         let resp: DocumentResponse<T> =
-            serialize_response(self.session.patch(url, body.as_str()).await?.body())?;
+            deserialize_response(self.session.patch(url, body.as_str()).await?.body())?;
         Ok(resp)
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -45,7 +45,7 @@ use maybe_async::maybe_async;
 
 use crate::{client::ClientExt, response::ArangoResult, ClientError};
 
-use super::{database::Database, response::serialize_response};
+use super::{database::Database, response::deserialize_response};
 
 use self::{
     auth::Auth,
@@ -173,7 +173,7 @@ impl<S, C: ClientExt> GenericConnection<C, S> {
             .join(&format!("/_api/user/{}/database", &self.username))
             .unwrap();
         let resp = self.session.get(url, "").await?;
-        let result: ArangoResult<HashMap<String, Permission>> = serialize_response(resp.body())?;
+        let result: ArangoResult<HashMap<String, Permission>> = deserialize_response(resp.body())?;
         Ok(result.unwrap())
     }
 }
@@ -377,7 +377,7 @@ impl<C: ClientExt> GenericConnection<C, Normal> {
             .post(url, &serde_json::to_string(&map)?)
             .await?;
 
-        serialize_response::<ArangoResult<bool>>(resp.body())?;
+        deserialize_response::<ArangoResult<bool>>(resp.body())?;
         self.db(name).await
     }
 
@@ -391,7 +391,7 @@ impl<C: ClientExt> GenericConnection<C, Normal> {
         let url = self.arango_url.join(&url_path).unwrap();
 
         let resp = self.session.delete(url, "").await?;
-        serialize_response::<ArangoResult<bool>>(resp.body())?;
+        deserialize_response::<ArangoResult<bool>>(resp.body())?;
         Ok(())
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -66,7 +66,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
             url.as_str()
         );
         let resp = self.session.get(url, "").await?;
-        let result: ArangoResult<Vec<CollectionResponse>> = serialize_response(resp.text())?;
+        let result: ArangoResult<Vec<CollectionResponse>> = serialize_response(resp.body())?;
         trace!("Collections retrieved");
         Ok(result.unwrap())
     }
@@ -89,7 +89,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
             .base_url
             .join(&format!("_api/collection/{}", name))
             .unwrap();
-        let resp: CollectionResponse = serialize_response(self.session.get(url, "").await?.text())?;
+        let resp: CollectionResponse = serialize_response(self.session.get(url, "").await?.body())?;
         Ok(Collection::from_response(self, &resp))
     }
 
@@ -116,7 +116,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
             .session
             .post(url, &serde_json::to_string(&map)?)
             .await?;
-        let _result: CollectionProperties = serialize_response(resp.text())?;
+        let _result: CollectionProperties = serialize_response(resp.body())?;
         self.collection(name).await
     }
 
@@ -135,7 +135,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
         }
 
         let resp: DropCollectionResponse =
-            serialize_response(self.session.delete(url, "").await?.text())?;
+            serialize_response(self.session.delete(url, "").await?.body())?;
         Ok(resp.id)
     }
 
@@ -147,7 +147,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
     pub async fn arango_version(&self) -> Result<Version, ClientError> {
         let url = self.base_url.join("_api/version").unwrap();
         let resp = self.session.get(url, "").await?;
-        let version: Version = serde_json::from_str(resp.text())?;
+        let version: Version = serde_json::from_str(resp.body())?;
         Ok(version)
     }
 
@@ -159,7 +159,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
     pub async fn info(&self) -> Result<DatabaseDetails, ClientError> {
         let url = self.base_url.join("_api/database/current").unwrap();
         let resp = self.session.get(url, "").await?;
-        let res: ArangoResult<DatabaseDetails> = serialize_response(resp.text())?;
+        let res: ArangoResult<DatabaseDetails> = serialize_response(resp.body())?;
         Ok(res.unwrap())
     }
 
@@ -181,7 +181,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
             .post(url, &serde_json::to_string(&aql)?)
             .await?;
         trace!("{:?}", serde_json::to_string(&aql));
-        serialize_response(resp.text())
+        serialize_response(resp.body())
     }
 
     /// Get next batch given the cursor id.
@@ -199,7 +199,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
             .unwrap();
         let resp = self.session.put(url, "").await?;
 
-        serialize_response(resp.text())
+        serialize_response(resp.body())
     }
 
     #[maybe_async]

--- a/src/database.rs
+++ b/src/database.rs
@@ -10,11 +10,10 @@ use url::Url;
 
 use maybe_async::maybe_async;
 
-use crate::collection::CollectionProperties;
 use crate::{
     aql::AqlQuery,
     client::ClientExt,
-    collection::{Collection, CollectionResponse},
+    collection::{Collection, CollectionProperties, CollectionResponse},
     connection::{DatabaseDetails, GenericConnection, Version},
     response::{deserialize_response, ArangoResult, Cursor},
     ClientError,

--- a/src/document.rs
+++ b/src/document.rs
@@ -7,16 +7,20 @@ use std::fmt::Debug;
 pub struct DocumentInsertOptions {
     /// Wait until document has been synced to disk.
     pub wait_for_sync: Option<bool>,
-    /// Additionally return the complete new document under the attribute new in the result.
+    /// Additionally return the complete new document under the attribute new in
+    /// the result.
     pub return_new: Option<bool>,
-    /// Additionally return the complete old document under the attribute old in the result. Only available if the overwrite option is used.
+    /// Additionally return the complete old document under the attribute old in
+    /// the result. Only available if the overwrite option is used.
     pub return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the created document.
     /// This option can be used to save some network traffic.
     pub silent: Option<bool>,
     /// If set to true, the insert becomes a replace-insert.
-    /// If a document with the same _key already exists the new document is not rejected with unique constraint violated but will replace the old document.
+    /// If a document with the same _key already exists the new document is not
+    /// rejected with unique constraint violated but will replace the old
+    /// document.
     pub overwrite: Option<bool>,
     /// TODO add nice formatted documentation from official doc
     #[cfg(arango3_7)]
@@ -31,9 +35,11 @@ pub struct DocumentUpdateOptions {
     /// Wait until document has been synced to disk.
     pub wait_for_sync: Option<bool>,
     pub ignore_revs: Option<bool>,
-    /// Additionally return the complete new document under the attribute new in the result.
+    /// Additionally return the complete new document under the attribute new in
+    /// the result.
     pub return_new: Option<bool>,
-    /// Additionally return the complete old document under the attribute old in the result. Only available if the overwrite option is used.
+    /// Additionally return the complete old document under the attribute old in
+    /// the result. Only available if the overwrite option is used.
     pub return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the created document.
@@ -45,22 +51,37 @@ pub enum DocumentOverwriteMode {
     /// If a document with the specified _key value exists already,
     /// nothing will be done and no write operation will be carried out.
     /// The insert operation will return success in this case.
-    /// This mode does not support returning the old document version using RETURN OLD.
-    /// When using RETURN NEW, null will be returned in case the document already existed.
+    /// This mode does not support returning the old document version using
+    /// RETURN OLD. When using RETURN NEW, null will be returned in case the
+    /// document already existed.
     Ignore,
-    /// If a document with the specified _key value exists already, it will be overwritten with the specified document value.
-    /// This mode will also be used when no overwrite mode is specified but the overwrite flag is set to true.
-    ///
+    /// If a document with the specified _key value exists already, it will be
+    /// overwritten with the specified document value. This mode will also
+    /// be used when no overwrite mode is specified but the overwrite flag is
+    /// set to true.
     Replace,
-    /// If a document with the specified _key value exists already, it will be patched (partially updated) with the specified document value.
-    /// The overwrite mode can be further controlled via the keepNull and mergeObjects parameters
+    /// If a document with the specified _key value exists already, it will be
+    /// patched (partially updated) with the specified document value.
+    /// The overwrite mode can be further controlled via the keepNull and
+    /// mergeObjects parameters
     Update,
-    /// if a document with the specified _key value exists already, return a unique constraint violation error so that the insert operation fails. This is also the default behavior in case the overwrite mode is not set, and the overwrite flag is false or not set either.
+    /// if a document with the specified _key value exists already, return a
+    /// unique constraint violation error so that the insert operation fails.
+    /// This is also the default behavior in case the overwrite mode is not set,
+    /// and the overwrite flag is false or not set either.
     ///
-    /// keepNull (optional): If the intention is to delete existing attributes with the update-insert command, the URL query parameter keepNull can be used with a value of false. This will modify the behavior of the patch command to remove any attributes from the existing document that are contained in the patch document with an attribute value of null.
+    /// keepNull (optional): If the intention is to delete existing attributes
+    /// with the update-insert command, the URL query parameter keepNull can be
+    /// used with a value of false. This will modify the behavior of the patch
+    /// command to remove any attributes from the existing document that are
+    /// contained in the patch document with an attribute value of null.
     /// This option controls the update-insert behavior only.
     ///
-    /// mergeObjects (optional): Controls whether objects (not arrays) will be merged if present in both the existing and the update-insert document. If set to false, the value in the patch document will overwrite the existing document’s value. If set to true, objects will be merged. The default is true. This option controls the update-insert behavior only.
+    /// mergeObjects (optional): Controls whether objects (not arrays) will be
+    /// merged if present in both the existing and the update-insert document.
+    /// If set to false, the value in the patch document will overwrite the
+    /// existing document’s value. If set to true, objects will be merged. The
+    /// default is true. This option controls the update-insert behavior only.
     /// TODO need to implement the two extra modes keepNull & mergeObjects
     Conflict,
 }
@@ -69,11 +90,13 @@ pub enum DocumentOverwriteMode {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum DocumentReadOptions {
-    /// If the “If-None-Match” header is given, then it must contain exactly one Etag.
-    /// The document is returned, if it has a different revision than the given Etag. Otherwise an HTTP 304 is returned.
+    /// If the “If-None-Match” header is given, then it must contain exactly one
+    /// Etag. The document is returned, if it has a different revision than
+    /// the given Etag. Otherwise an HTTP 304 is returned.
     IfNoneMatch(String),
-    ///  If the “If-Match” header is given, then it must contain exactly one Etag.
-    /// The document is returned, if it has the same revision as the given Etag. Otherwise a HTTP 412 is returned.
+    ///  If the “If-Match” header is given, then it must contain exactly one
+    /// Etag. The document is returned, if it has the same revision as the
+    /// given Etag. Otherwise a HTTP 412 is returned.
     IfMatch(String),
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// Options for document insertion.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentInsertOptions {
     /// Wait until document has been synced to disk.
@@ -27,7 +26,7 @@ pub struct DocumentInsertOptions {
     pub overwrite_mode: Option<DocumentOverwriteMode>,
 }
 /// Options for document update,
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentUpdateOptions {
     /// If the intention is to delete existing attributes with the patch
@@ -59,7 +58,7 @@ pub struct DocumentUpdateOptions {
     /// This option can be used to save some network traffic.
     pub silent: Option<bool>,
 }
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub enum DocumentOverwriteMode {
     /// If a document with the specified _key value exists already,
     /// nothing will be done and no write operation will be carried out.
@@ -99,7 +98,7 @@ pub enum DocumentOverwriteMode {
     Conflict,
 }
 /// Options for document replace,
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentReplaceOptions {
     /// Wait until document has been synced to disk.
@@ -124,7 +123,7 @@ pub struct DocumentReplaceOptions {
     pub if_match: Option<String>,
 }
 /// Options for document reading.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DocumentReadOptions {
     /// If the “If-None-Match” header is given, then it must contain exactly one
@@ -137,7 +136,7 @@ pub enum DocumentReadOptions {
     IfMatch(String),
 }
 /// Options for document removes,
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentRemoveOptions {
     /// Wait until document has been synced to disk.
@@ -153,7 +152,7 @@ pub struct DocumentRemoveOptions {
     /// by using the if-match HTTP header.
     pub if_match: Option<String>,
 }
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct DocumentHeader {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub _id: String,
@@ -164,7 +163,7 @@ pub struct DocumentHeader {
 }
 
 /// Standard Response when having CRUD operation on document
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct DocumentResponse<T> {
     #[serde(flatten)]
     /// May contain the { _key : String, _id : String, _rev:String } of the
@@ -179,7 +178,7 @@ pub struct DocumentResponse<T> {
     pub old: Option<T>,
 }
 /// Structure that represents a document within its content and header
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct Document<T> {
     #[serde(flatten)]
     pub header: DocumentHeader,

--- a/src/document.rs
+++ b/src/document.rs
@@ -42,9 +42,26 @@ pub struct DocumentUpdateOptions {
 }
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DocumentOverwriteMode {
+    /// If a document with the specified _key value exists already,
+    /// nothing will be done and no write operation will be carried out.
+    /// The insert operation will return success in this case.
+    /// This mode does not support returning the old document version using RETURN OLD.
+    /// When using RETURN NEW, null will be returned in case the document already existed.
     Ignore,
+    /// If a document with the specified _key value exists already, it will be overwritten with the specified document value.
+    /// This mode will also be used when no overwrite mode is specified but the overwrite flag is set to true.
+    ///
     Replace,
+    /// If a document with the specified _key value exists already, it will be patched (partially updated) with the specified document value.
+    /// The overwrite mode can be further controlled via the keepNull and mergeObjects parameters
     Update,
+    /// if a document with the specified _key value exists already, return a unique constraint violation error so that the insert operation fails. This is also the default behavior in case the overwrite mode is not set, and the overwrite flag is false or not set either.
+    ///
+    /// keepNull (optional): If the intention is to delete existing attributes with the update-insert command, the URL query parameter keepNull can be used with a value of false. This will modify the behavior of the patch command to remove any attributes from the existing document that are contained in the patch document with an attribute value of null.
+    /// This option controls the update-insert behavior only.
+    ///
+    /// mergeObjects (optional): Controls whether objects (not arrays) will be merged if present in both the existing and the update-insert document. If set to false, the value in the patch document will overwrite the existing document’s value. If set to true, objects will be merged. The default is true. This option controls the update-insert behavior only.
+    /// TODO need to implement the two extra modes keepNull & mergeObjects
     Conflict,
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -215,22 +215,6 @@ pub struct DocumentHeader {
     pub _rev: String,
 }
 
-/// Content Response when having CRUD operation on document
-#[derive(Serialize, Deserialize, Debug)]
-pub struct OperationResponse<T> {
-    #[serde(flatten)]
-    /// May contain the { _key : String, _id : String, _rev:String } of the
-    /// document
-    pub header: DocumentHeader,
-    /// May contain the document after being created/replace/updated
-    pub new: Option<T>,
-    #[serde(rename = "_oldRev")]
-    /// May contain the old revision of the document after update/replace
-    pub _old_rev: Option<String>,
-    /// May contain the old the document after update/replace/remove
-    pub old: Option<T>,
-}
-
 /// Standard Response when having CRUD operation on document
 /// Todo could add more response variant like shown on official doc
 /// 200: is returned if the document was found
@@ -270,24 +254,37 @@ impl<T> DocumentResponse<T> {
         }
     }
 
-    /// Should give None or Some(Response)
-    pub fn get_response(self) -> Option<OperationResponse<T>> {
-        if let DocumentResponse::Response {
-            header,
-            old,
-            new,
-            _old_rev,
-        } = self
-        {
-            Some(OperationResponse {
-                header,
-                old,
-                new,
-                _old_rev,
-            })
+    /// Return the document header contained inside the response
+    pub fn header(&self) -> Option<&DocumentHeader> {
+        if let DocumentResponse::Response { header, .. } = self {
+            Some(header)
         } else {
             None
         }
+    }
+    /// Return the old document before changes
+    pub fn old_doc(&self) -> Option<&T> {
+        Option::from(if let DocumentResponse::Response { old, .. } = self {
+            old
+        } else {
+            &None
+        })
+    }
+    /// Return the new document
+    pub fn new_doc(&self) -> Option<&T> {
+        Option::from(if let DocumentResponse::Response { new, .. } = self {
+            new
+        } else {
+            &None
+        })
+    }
+    /// return the old revision of the document
+    pub fn old_rev(&self) -> Option<&String> {
+        Option::from(if let DocumentResponse::Response { _old_rev, .. } = self {
+            _old_rev
+        } else {
+            &None
+        })
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -32,7 +32,11 @@ pub struct DocumentInsertOptions {
     #[builder(default, setter(strip_option))]
     overwrite_mode: Option<DocumentOverwriteMode>,
 }
-
+impl Default for DocumentInsertOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
 /// Options for document update,
 #[derive(Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -110,29 +110,31 @@ pub enum DocumentOverwriteMode {
     Conflict,
 }
 /// Options for document replace,
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentReplaceOptions {
     /// Wait until document has been synced to disk.
-    pub wait_for_sync: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    wait_for_sync: Option<bool>,
     /// By default, or if this is set to true, the _rev attributes in the given
     /// document is ignored. If this is set to false, then the _rev
     /// attribute given in the body document is taken as a precondition. The
     /// document is only replaced if the current revision is the one specified.
-    pub ignore_revs: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    ignore_revs: Option<bool>,
     /// Additionally return the complete new document under the attribute new in
     /// the result.
-    pub return_new: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_new: Option<bool>,
     /// Additionally return the complete old document under the attribute old in
     /// the result.
-    pub return_old: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the replaced document.
     /// This option can be used to save some network traffic.
-    pub silent: Option<bool>,
-    /// You can conditionally replace a document based on a target revision id
-    /// by using the if-match HTTP header.
-    pub if_match: Option<String>,
+    #[builder(default, setter(strip_option))]
+    silent: Option<bool>,
 }
 /// Options for document reading.
 #[derive(Serialize, Deserialize)]

--- a/src/document.rs
+++ b/src/document.rs
@@ -32,6 +32,7 @@ pub struct DocumentInsertOptions {
     #[builder(default, setter(strip_option))]
     overwrite_mode: Option<DocumentOverwriteMode>,
 }
+
 /// Options for document update,
 #[derive(Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
@@ -72,6 +73,7 @@ pub struct DocumentUpdateOptions {
     #[builder(default, setter(strip_option))]
     silent: Option<bool>,
 }
+
 #[derive(Serialize, Deserialize)]
 pub enum DocumentOverwriteMode {
     /// If a document with the specified _key value exists already,
@@ -111,6 +113,7 @@ pub enum DocumentOverwriteMode {
     /// TODO need to implement the two extra modes keepNull & mergeObjects
     Conflict,
 }
+
 /// Options for document replace,
 #[derive(Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
@@ -138,6 +141,7 @@ pub struct DocumentReplaceOptions {
     #[builder(default, setter(strip_option))]
     silent: Option<bool>,
 }
+
 /// Options for document reading.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -151,6 +155,7 @@ pub enum DocumentReadOptions {
     /// given Etag. Otherwise a HTTP 412 is returned.
     IfMatch(String),
 }
+
 /// Options for document removes,
 #[derive(Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -174,7 +174,7 @@ pub struct DocumentRemoveOptions {
     silent: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DocumentHeader {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub _id: String,

--- a/src/document.rs
+++ b/src/document.rs
@@ -30,7 +30,16 @@ pub struct DocumentInsertOptions {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentUpdateOptions {
+    /// If the intention is to delete existing attributes with the patch
+    /// command, the URL query parameter keepNull can be used with a value of
+    /// false. This will modify the behavior of the patch command to remove any
+    /// attributes from the existing document that are contained in the patch
+    /// document with an attribute value of null.
     pub keep_null: Option<bool>,
+    /// Controls whether objects (not arrays) will be merged if present in both
+    /// the existing and the patch document. If set to false, the value in the
+    /// patch document will overwrite the existing document’s value. If set to
+    /// true, objects will be merged. The default is true.
     pub merge_objects: Option<bool>,
     /// Wait until document has been synced to disk.
     pub wait_for_sync: Option<bool>,
@@ -42,11 +51,11 @@ pub struct DocumentUpdateOptions {
     /// Additionally return the complete new document under the attribute new in
     /// the result.
     pub return_new: Option<bool>,
-    /// Additionally return the complete old document under the attribute old in
-    /// the result. Only available if the overwrite option is used.
+    /// Return additionally the complete previous revision of the changed
+    /// document under the attribute old in the result.
     pub return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
-    /// No meta-data will be returned for the created document.
+    /// No meta-data will be returned for the updated document.
     /// This option can be used to save some network traffic.
     pub silent: Option<bool>,
 }
@@ -89,7 +98,7 @@ pub enum DocumentOverwriteMode {
     /// TODO need to implement the two extra modes keepNull & mergeObjects
     Conflict,
 }
-/// Options for document update,
+/// Options for document replace,
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentReplaceOptions {
@@ -104,10 +113,10 @@ pub struct DocumentReplaceOptions {
     /// the result.
     pub return_new: Option<bool>,
     /// Additionally return the complete old document under the attribute old in
-    /// the result. Only available if the overwrite option is used.
+    /// the result.
     pub return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
-    /// No meta-data will be returned for the created document.
+    /// No meta-data will be returned for the replaced document.
     /// This option can be used to save some network traffic.
     pub silent: Option<bool>,
     /// You can conditionally replace a document based on a target revision id

--- a/src/document.rs
+++ b/src/document.rs
@@ -225,24 +225,16 @@ pub enum DocumentResponse<T> {
 impl<T> DocumentResponse<T> {
     /// Should be true when the server send back an empty object {}
     pub fn is_silent(&self) -> bool {
-        if let DocumentResponse::Silent = self {
-            true
-        } else {
-            false
+        match self {
+            DocumentResponse::Silent => true,
+            _ => false,
         }
     }
     /// Should be true if there is a response from the server
     pub fn has_response(&self) -> bool {
-        if let DocumentResponse::Response {
-            header,
-            old,
-            new,
-            _old_rev,
-        } = self
-        {
-            true
-        } else {
-            false
+        match self {
+            DocumentResponse::Response { .. } => true,
+            _ => false,
         }
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -150,6 +150,11 @@ pub struct DocumentReplaceOptions {
     silent: Option<bool>,
 }
 
+impl Default for DocumentReplaceOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
 /// Options for document reading.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -308,7 +308,7 @@ where
 }
 
 /// Structure that represents a document within its content and header
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Document<T> {
     #[serde(flatten)]
     pub header: DocumentHeader,

--- a/src/document.rs
+++ b/src/document.rs
@@ -187,6 +187,12 @@ pub struct DocumentRemoveOptions {
     silent: Option<bool>,
 }
 
+impl Default for DocumentRemoveOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocumentHeader {
     #[serde(skip_serializing_if = "String::is_empty")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -298,12 +298,6 @@ where
     {
         let mut obj = serde_json::Value::deserialize(deserializer)?;
 
-        if obj.get_mut("error").is_some() {
-            return ArangoError::deserialize(obj)
-                .map(DocumentResponse::Err)
-                .map_err(de::Error::custom);
-        }
-
         let json = obj.as_object_mut().unwrap();
 
         if json.contains_key("_key") != true {

--- a/src/document.rs
+++ b/src/document.rs
@@ -167,8 +167,14 @@ pub enum DocumentReadOptions {
     /// Etag. The document is returned, if it has the same revision as the
     /// given Etag. Otherwise a HTTP 412 is returned.
     IfMatch(String),
+    NoHeader,
 }
 
+impl Default for DocumentReadOptions {
+    fn default() -> Self {
+        Self::NoHeader
+    }
+}
 /// Options for document removes,
 #[derive(Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -34,6 +34,10 @@ pub struct DocumentUpdateOptions {
     pub merge_objects: Option<bool>,
     /// Wait until document has been synced to disk.
     pub wait_for_sync: Option<bool>,
+    /// By default, or if this is set to true, the _rev attributes in the given
+    /// document is ignored. If this is set to false, then the _rev
+    /// attribute given in the body document is taken as a precondition. The
+    /// document is only update if the current revision is the one specified.
     pub ignore_revs: Option<bool>,
     /// Additionally return the complete new document under the attribute new in
     /// the result.

--- a/src/document.rs
+++ b/src/document.rs
@@ -136,7 +136,23 @@ pub enum DocumentReadOptions {
     /// given Etag. Otherwise a HTTP 412 is returned.
     IfMatch(String),
 }
-
+/// Options for document removes,
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentRemoveOptions {
+    /// Wait until document has been synced to disk.
+    pub wait_for_sync: Option<bool>,
+    /// Additionally return the complete old document under the attribute old in
+    /// the result.
+    pub return_old: Option<bool>,
+    /// If set to true, an empty object will be returned as response.
+    /// No meta-data will be returned for the created document.
+    /// This option can be used to save some network traffic.
+    pub silent: Option<bool>,
+    /// You can conditionally replace a document based on a target revision id
+    /// by using the if-match HTTP header.
+    pub if_match: Option<String>,
+}
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocumentHeader {
     #[serde(skip_serializing_if = "String::is_empty")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -150,21 +150,21 @@ pub enum DocumentReadOptions {
     IfMatch(String),
 }
 /// Options for document removes,
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentRemoveOptions {
     /// Wait until document has been synced to disk.
-    pub wait_for_sync: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    wait_for_sync: Option<bool>,
     /// Additionally return the complete old document under the attribute old in
     /// the result.
-    pub return_old: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the created document.
     /// This option can be used to save some network traffic.
-    pub silent: Option<bool>,
-    /// You can conditionally replace a document based on a target revision id
-    /// by using the if-match HTTP header.
-    pub if_match: Option<String>,
+    #[builder(default, setter(strip_option))]
+    silent: Option<bool>,
 }
 #[derive(Serialize, Deserialize)]
 pub struct DocumentHeader {

--- a/src/document.rs
+++ b/src/document.rs
@@ -31,7 +31,7 @@ pub struct DocumentInsertOptions {
     overwrite_mode: Option<DocumentOverwriteMode>,
 }
 /// Options for document update,
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentUpdateOptions {
     /// If the intention is to delete existing attributes with the patch
@@ -39,29 +39,36 @@ pub struct DocumentUpdateOptions {
     /// false. This will modify the behavior of the patch command to remove any
     /// attributes from the existing document that are contained in the patch
     /// document with an attribute value of null.
-    pub keep_null: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    keep_null: Option<bool>,
     /// Controls whether objects (not arrays) will be merged if present in both
     /// the existing and the patch document. If set to false, the value in the
     /// patch document will overwrite the existing document’s value. If set to
     /// true, objects will be merged. The default is true.
-    pub merge_objects: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    merge_objects: Option<bool>,
     /// Wait until document has been synced to disk.
-    pub wait_for_sync: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    wait_for_sync: Option<bool>,
     /// By default, or if this is set to true, the _rev attributes in the given
     /// document is ignored. If this is set to false, then the _rev
     /// attribute given in the body document is taken as a precondition. The
     /// document is only update if the current revision is the one specified.
-    pub ignore_revs: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    ignore_revs: Option<bool>,
     /// Additionally return the complete new document under the attribute new in
     /// the result.
-    pub return_new: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_new: Option<bool>,
     /// Return additionally the complete previous revision of the changed
     /// document under the attribute old in the result.
-    pub return_old: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the updated document.
     /// This option can be used to save some network traffic.
-    pub silent: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    silent: Option<bool>,
 }
 #[derive(Serialize, Deserialize)]
 pub enum DocumentOverwriteMode {

--- a/src/document.rs
+++ b/src/document.rs
@@ -77,7 +77,11 @@ pub struct DocumentUpdateOptions {
     #[builder(default, setter(strip_option))]
     silent: Option<bool>,
 }
-
+impl Default for DocumentUpdateOptions {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
 #[derive(Serialize, Deserialize)]
 pub enum DocumentOverwriteMode {
     /// If a document with the specified _key value exists already,

--- a/src/document.rs
+++ b/src/document.rs
@@ -163,16 +163,22 @@ pub struct DocumentHeader {
     pub _rev: String,
 }
 
+/// Standard Response when having CRUD operation on document
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocumentResponse<T> {
     #[serde(flatten)]
+    /// May contain the { _key : String, _id : String, _rev:String } of the
+    /// document
     pub header: Option<DocumentHeader>,
+    /// May contain the document after being created/replace/updated
     pub new: Option<T>,
     #[serde(rename = "_oldRev")]
+    /// May contain the old revision of the document after update/replace
     pub _old_rev: Option<String>,
+    /// May contain the old the document after update/replace/remove
     pub old: Option<T>,
 }
-
+/// Structure that represents a document within its content and header
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Document<T> {
     #[serde(flatten)]

--- a/src/document.rs
+++ b/src/document.rs
@@ -190,7 +190,7 @@ pub struct OperationResponse<T> {
     #[serde(flatten)]
     /// May contain the { _key : String, _id : String, _rev:String } of the
     /// document
-    pub header: Option<DocumentHeader>,
+    pub header: DocumentHeader,
     /// May contain the document after being created/replace/updated
     pub new: Option<T>,
     #[serde(rename = "_oldRev")]
@@ -248,7 +248,7 @@ impl<T> DocumentResponse<T> {
         } = self
         {
             Some(OperationResponse {
-                header: Some(header),
+                header,
                 old,
                 new,
                 _old_rev,

--- a/src/document.rs
+++ b/src/document.rs
@@ -89,7 +89,31 @@ pub enum DocumentOverwriteMode {
     /// TODO need to implement the two extra modes keepNull & mergeObjects
     Conflict,
 }
-
+/// Options for document update,
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentReplaceOptions {
+    /// Wait until document has been synced to disk.
+    pub wait_for_sync: Option<bool>,
+    /// By default, or if this is set to true, the _rev attributes in the given
+    /// document is ignored. If this is set to false, then the _rev
+    /// attribute given in the body document is taken as a precondition. The
+    /// document is only replaced if the current revision is the one specified.
+    pub ignore_revs: Option<bool>,
+    /// Additionally return the complete new document under the attribute new in
+    /// the result.
+    pub return_new: Option<bool>,
+    /// Additionally return the complete old document under the attribute old in
+    /// the result. Only available if the overwrite option is used.
+    pub return_old: Option<bool>,
+    /// If set to true, an empty object will be returned as response.
+    /// No meta-data will be returned for the created document.
+    /// This option can be used to save some network traffic.
+    pub silent: Option<bool>,
+    /// You can conditionally replace a document based on a target revision id
+    /// by using the if-match HTTP header.
+    pub if_match: Option<String>,
+}
 /// Options for document reading.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/src/document.rs
+++ b/src/document.rs
@@ -185,7 +185,7 @@ pub struct DocumentHeader {
 }
 
 /// Content Response when having CRUD operation on document
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct OperationResponse<T> {
     #[serde(flatten)]
     /// May contain the { _key : String, _id : String, _rev:String } of the

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,29 +1,34 @@
 use serde::{Deserialize, Serialize};
-
 /// Options for document insertion.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentInsertOptions {
     /// Wait until document has been synced to disk.
-    pub wait_for_sync: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    wait_for_sync: Option<bool>,
     /// Additionally return the complete new document under the attribute new in
     /// the result.
-    pub return_new: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_new: Option<bool>,
     /// Additionally return the complete old document under the attribute old in
     /// the result. Only available if the overwrite option is used.
-    pub return_old: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    return_old: Option<bool>,
     /// If set to true, an empty object will be returned as response.
     /// No meta-data will be returned for the created document.
     /// This option can be used to save some network traffic.
-    pub silent: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    silent: Option<bool>,
     /// If set to true, the insert becomes a replace-insert.
     /// If a document with the same _key already exists the new document is not
     /// rejected with unique constraint violated but will replace the old
     /// document.
-    pub overwrite: Option<bool>,
+    #[builder(default, setter(strip_option))]
+    overwrite: Option<bool>,
     /// TODO add nice formatted documentation from official doc
     #[cfg(arango3_7)]
-    pub overwrite_mode: Option<DocumentOverwriteMode>,
+    #[builder(default, setter(strip_option))]
+    overwrite_mode: Option<DocumentOverwriteMode>,
 }
 /// Options for document update,
 #[derive(Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,3 +402,6 @@ pub mod document;
 pub mod error;
 mod query;
 pub mod response;
+#[macro_use]
+extern crate typed_builder;
+extern crate serde_qs as qs;

--- a/src/response.rs
+++ b/src/response.rs
@@ -26,7 +26,7 @@ use super::aql::QueryStats;
 /// response of success and failure.
 ///
 /// When ArangoDB server response error code, then an error would be cast.
-pub(crate) fn serialize_response<T>(text: &str) -> Result<T, ClientError>
+pub(crate) fn deserialize_response<T>(text: &str) -> Result<T, ClientError>
 where
     T: DeserializeOwned,
 {

--- a/src/response.rs
+++ b/src/response.rs
@@ -167,12 +167,12 @@ mod test {
     #[test]
     fn response() {
         let text = "{\"id\":\"9947\",\"name\":\"relation\",\"status\":2,\"type\":3,\"isSystem\": \
-                false,\"globallyUniqueId\":\"hD260BE2A30F9/9947\"}";
+                    false,\"globallyUniqueId\":\"hD260BE2A30F9/9947\"}";
         let result = serde_json::from_str::<Response<CollectionResponse>>(text);
         assert_eq!(result.is_ok(), true, "failed: {:?}", result);
 
-        let text = "{\"error\":false,\"code\":412,\"id\":\"9947\",\"name\":\"relation\",\"status\":2,\"type\":3,\"isSystem\": \
-        false,\"globallyUniqueId\":\"hD260BE2A30F9/9947\"}";
+        let text = "{\"error\":false,\"code\":412,\"id\":\"9947\",\"name\":\"relation\",\"status\"\
+                    :2,\"type\":3,\"isSystem\": false,\"globallyUniqueId\":\"hD260BE2A30F9/9947\"}";
         let result = serde_json::from_str::<Response<CollectionResponse>>(text);
         assert_eq!(result.is_ok(), true, "failed: {:?}", result);
 

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -5,8 +5,10 @@ use log::trace;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 
-use arangors::collection::{CollectionPropertiesOptions, CollectionStatus, CollectionType};
-use arangors::{ClientError, Connection, Document};
+use arangors::{
+    collection::{CollectionPropertiesOptions, CollectionStatus, CollectionType},
+    ClientError, Connection, Document,
+};
 use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup};
 
 pub mod common;

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -53,13 +53,17 @@ async fn test_create_and_drop_collection() {
         .await
         .unwrap();
     let mut database = conn.db("test_db").await.unwrap();
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(
+        coll.is_err(),
+        true,
+        "The collection should have been drop previously"
+    );
+    let coll = database.create_collection(collection_name).await;
+    assert_eq!(coll.is_err(), false, "It should have create the collection");
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
-    let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
-    let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    assert_eq!(coll.is_err(), false, "It should drop the collection");
 }
 
 #[maybe_async::test(
@@ -81,13 +85,12 @@ async fn test_get_properties() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
 
     let properties = coll.unwrap().properties().await;
     assert_eq!(properties.is_err(), false);
@@ -116,7 +119,7 @@ async fn test_get_properties() {
     assert_eq!(result.detail.write_concern, 1);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -138,13 +141,13 @@ async fn test_get_document_count() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let count = coll.document_count().await;
 
@@ -174,7 +177,7 @@ async fn test_get_document_count() {
     assert_eq!(updated_result.info.count, Some(1));
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -196,7 +199,7 @@ async fn test_get_statistics() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true, "drop collection");
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false, "create collection");
@@ -228,7 +231,12 @@ async fn test_get_statistics() {
     assert_eq!(result.figures.indexes.size, Some(0), "indexes size");
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false, "fail to drop collection: {:?}", coll);
+    assert_eq!(
+        coll.is_err(),
+        false,
+        "fail to dropped collection : {:?}",
+        coll
+    );
 }
 
 #[maybe_async::test(
@@ -250,13 +258,13 @@ async fn test_get_revision_id() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let revision = coll.revision_id().await;
 
@@ -277,7 +285,7 @@ async fn test_get_revision_id() {
     assert_eq!(result.detail.write_concern, 1);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -299,13 +307,13 @@ async fn test_get_checksum() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let checksum = coll.checksum().await;
 
@@ -351,7 +359,7 @@ async fn test_get_checksum() {
     assert_eq!(updated_result.checksum.is_empty(), false);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -373,13 +381,13 @@ async fn test_put_load() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let load = coll.load(true).await;
 
@@ -415,7 +423,7 @@ async fn test_put_load() {
     assert_eq!(updated_result.r#type, CollectionType::Document);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -437,13 +445,13 @@ async fn test_put_unload() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let unload = coll.unload().await;
 
@@ -461,7 +469,7 @@ async fn test_put_unload() {
     assert_eq!(result.r#type, CollectionType::Document);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -483,13 +491,13 @@ async fn test_put_load_indexes_into_memory() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let load_index = coll.load_indexes().await;
 
@@ -497,7 +505,7 @@ async fn test_put_load_indexes_into_memory() {
     assert_eq!(result, true);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -519,13 +527,13 @@ async fn test_put_changes_properties() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
 
     let updated_properties = coll
@@ -550,7 +558,7 @@ async fn test_put_changes_properties() {
     assert_eq!(result.detail.write_concern, 1);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -572,13 +580,13 @@ async fn test_put_rename() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let new_name = "test_collection_renamed_2";
     let renamed = coll.rename(new_name).await;
@@ -589,8 +597,6 @@ async fn test_put_rename() {
     assert_eq!(result.status, CollectionStatus::Loaded);
     assert_eq!(result.r#type, CollectionType::Document);
 
-    let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
     let coll = database.drop_collection(new_name).await;
     assert_eq!(coll.is_err(), false);
 }
@@ -615,13 +621,13 @@ async fn test_put_recalculate() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
+    assert_eq!(coll.is_err(), true, "Dropped collection ");
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
 
     let coll = database.collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+
     let coll = coll.unwrap();
     let recalculate = coll.recalculate_count().await;
 
@@ -629,7 +635,7 @@ async fn test_put_recalculate() {
     assert_eq!(result, true);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[cfg(any(feature = "mmfiles"))]
@@ -650,9 +656,6 @@ async fn test_put_rotate_journal() {
         .await
         .unwrap();
     let mut database = conn.db("test_db").await.unwrap();
-
-    let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
 
     let coll = database.create_collection(collection_name).await;
     assert_eq!(coll.is_err(), false);
@@ -677,5 +680,5 @@ async fn test_put_rotate_journal() {
     // assert_eq!(result, true, "rotate result should be true");
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -805,7 +805,7 @@ async fn test_delete_remove_document() {
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),
-            Some(DocumentRemoveOptions::builder().return_old(true).build()),
+            DocumentRemoveOptions::builder().return_old(true).build(),
             None,
         )
         .await;
@@ -842,7 +842,7 @@ async fn test_delete_remove_document() {
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),
-            Some(DocumentRemoveOptions::builder().silent(true).build()),
+            DocumentRemoveOptions::builder().silent(true).build(),
             None,
         )
         .await;
@@ -861,7 +861,11 @@ async fn test_delete_remove_document() {
     let _key = header._key;
     let _rev = header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
-        .remove_document(_key.as_str(), None, Some("_rere_dsds_DSds".to_string()))
+        .remove_document(
+            _key.as_str(),
+            Default::default(),
+            Some("_rere_dsds_DSds".to_string()),
+        )
         .await;
 
     assert_eq!(
@@ -872,13 +876,15 @@ async fn test_delete_remove_document() {
     );
     // Fourth test to check that we get error if we tried to remove a doc that has
     // already been removed or that does not exist
-    let remove: Result<DocumentResponse<Value>, ClientError> =
-        coll.remove_document(_key.as_str(), None, None).await;
+    let remove: Result<DocumentResponse<Value>, ClientError> = coll
+        .remove_document(_key.as_str(), Default::default(), None)
+        .await;
 
     assert_eq!(remove.is_err(), false, "We should remove the doc");
 
-    let remove: Result<DocumentResponse<Value>, ClientError> =
-        coll.remove_document(_key.as_str(), None, None).await;
+    let remove: Result<DocumentResponse<Value>, ClientError> = coll
+        .remove_document(_key.as_str(), Default::default(), None)
+        .await;
 
     assert_eq!(
         remove.is_err(),

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -796,7 +796,7 @@ async fn test_post_replace_document() {
     assert_eq!(
         result.old.is_none(),
         true,
-        "We should not get told old doc back"
+        "We should not get the old doc back"
     );
     // Second test to try out the silence mode
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -48,7 +48,7 @@ async fn test_post_create_document() {
     }));
 
     // First test is to create a simple document without options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
@@ -81,7 +81,7 @@ async fn test_post_create_document() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().return_new(true).build()),
+            DocumentInsertOptions::builder().return_new(true).build(),
         )
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
@@ -114,12 +114,10 @@ async fn test_post_create_document() {
     let update = coll
         .create_document(
             test_doc,
-            Some(
-                DocumentInsertOptions::builder()
-                    .return_old(true)
-                    .overwrite(true)
-                    .build(),
-            ),
+            DocumentInsertOptions::builder()
+                .return_old(true)
+                .overwrite(true)
+                .build(),
         )
         .await;
     assert_eq!(update.is_ok(), true, "succeed update a document");
@@ -147,7 +145,7 @@ async fn test_post_create_document() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().silent(true).build()),
+            DocumentInsertOptions::builder().silent(true).build(),
         )
         .await;
 
@@ -194,7 +192,7 @@ async fn test_post_create_document_3_7() {
     }));
 
     // First test is to create a simple document without options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
@@ -225,7 +223,7 @@ async fn test_post_create_document_3_7() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().return_new(true).build()),
+            DocumentInsertOptions::builder().return_new(true).build(),
         )
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
@@ -258,12 +256,10 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(
-                DocumentInsertOptions::builder()
-                    .return_old(true)
-                    .overwrite(true)
-                    .build(),
-            ),
+            DocumentInsertOptions::builder()
+                .return_old(true)
+                .overwrite(true)
+                .build(),
         )
         .await;
 
@@ -290,7 +286,7 @@ async fn test_post_create_document_3_7() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().silent(true).build()),
+            DocumentInsertOptions::builder().silent(true).build(),
         )
         .await;
 
@@ -309,11 +305,9 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(
-                DocumentInsertOptions::builder()
-                    .return_new(true)
-                    .overwrite_mode(DocumentOverwriteMode::Ignore),
-            ),
+            DocumentInsertOptions::builder()
+                .return_new(true)
+                .overwrite_mode(DocumentOverwriteMode::Ignore),
         )
         .await;
 
@@ -331,7 +325,7 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Replace)),
+            DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Replace),
         )
         .await;
 
@@ -355,7 +349,7 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Update)),
+            DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Update),
         )
         .await;
 
@@ -405,7 +399,7 @@ async fn test_get_read_document() {
     }));
 
     // First test is to read a simple document without options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
     let header = create.unwrap().get_response().unwrap().header;
@@ -479,7 +473,7 @@ async fn test_get_read_document_header() {
     }));
 
     // First test is to read a simple document without options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
     let resp = create.unwrap().get_response().unwrap();
@@ -576,7 +570,7 @@ async fn test_patch_update_document() {
     }));
 
     // First test is to update a simple document without options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
@@ -674,7 +668,7 @@ async fn test_post_replace_document() {
     }));
 
     // First test is to replace  simple document with new & old options
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let response = create.unwrap().get_response().unwrap();
@@ -799,7 +793,7 @@ async fn test_delete_remove_document() {
 
     // First test is to remove a simple document with old options
     let create: Result<DocumentResponse<Document<Value>>, ClientError> =
-        coll.create_document(test_doc, None).await;
+        coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let response = create.unwrap().get_response().unwrap();
@@ -839,7 +833,7 @@ async fn test_delete_remove_document() {
     let test_doc: Document<Value> = Document::new(json!({ "no":1 ,
     "testDescription":"update document"
     }));
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
     let response = create.unwrap().get_response().unwrap();
     let header = response.header;
     let _key = header._key;
@@ -860,7 +854,7 @@ async fn test_delete_remove_document() {
     let test_doc: Document<Value> = Document::new(json!({ "no":1 ,
     "testDescription":"update document"
     }));
-    let create = coll.create_document(test_doc, None).await;
+    let create = coll.create_document(test_doc, Default::default()).await;
     let response = create.unwrap().get_response().unwrap();
     let header = response.header;
     let _key = header._key;

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -52,9 +52,21 @@ async fn test_post_create_document() {
     let result = create.unwrap();
 
     let header = result.header.unwrap();
-    assert_eq!(header._id.is_empty(), false);
-    assert_eq!(header._rev.is_empty(), false);
-    assert_eq!(header._key.is_empty(), false);
+    assert_eq!(
+        header._id.is_empty(),
+        false,
+        "We should get the id of the document"
+    );
+    assert_eq!(
+        header._rev.is_empty(),
+        false,
+        "We should get the revision of the document"
+    );
+    assert_eq!(
+        header._key.is_empty(),
+        false,
+        "We should get the key of the document"
+    );
     // Second test is to create a simple document with option to get the new document back
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "testDescription":"Test with new"
@@ -75,7 +87,11 @@ async fn test_post_create_document() {
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
 
-    assert_eq!(result.new.is_some(), true);
+    assert_eq!(
+        result.new.is_some(),
+        true,
+        "We should get the new document under the 'new' property"
+    );
 
     let doc = result.new.unwrap();
 
@@ -112,12 +128,15 @@ async fn test_post_create_document() {
     assert_eq!(result.old.is_some(), true);
 
     let old_doc = result.old.unwrap();
-    assert_eq!(old_doc.document["testDescription"], "Test with new");
+    assert_eq!(
+        old_doc.document["testDescription"], "Test with new",
+        "We should get the old document under the 'old' property"
+    );
 
     let header = result.header.unwrap();
-    assert_eq!(header._id.is_empty(), false);
-    assert_eq!(header._rev.is_empty(), false);
-    assert_eq!(header._key.is_empty(), false);
+    assert_eq!(header._id.is_empty(), false,);
+    assert_eq!(header._rev.is_empty(), false,);
+    assert_eq!(header._key.is_empty(), false,);
 
     // Fourth testis about the silent option
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
@@ -187,9 +206,21 @@ async fn test_post_create_document_3_7() {
 
     let result = create.unwrap();
     let header = result.header.unwrap();
-    assert_eq!(header._id.is_empty(), false);
-    assert_eq!(header._rev.is_empty(), false);
-    assert_eq!(header._key.is_empty(), false);
+    assert_eq!(
+        header._id.is_empty(),
+        false,
+        "We should get the id of the document"
+    );
+    assert_eq!(
+        header._rev.is_empty(),
+        false,
+        "We should get the revision of the document"
+    );
+    assert_eq!(
+        header._key.is_empty(),
+        false,
+        "We should get the key of the document"
+    );
     // Second test is to create a simple document with option to get the new document back
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "testDescription":"Test with new"
@@ -211,7 +242,11 @@ async fn test_post_create_document_3_7() {
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
 
-    assert_eq!(result.new.is_some(), true);
+    assert_eq!(
+        result.new.is_some(),
+        true,
+        "we should get the new document under 'new' property"
+    );
 
     let doc = result.new.unwrap();
 
@@ -248,7 +283,10 @@ async fn test_post_create_document_3_7() {
     assert_eq!(result.old.is_some(), true);
 
     let old_doc = result.old.unwrap();
-    assert_eq!(old_doc.document["testDescription"], "Test with new");
+    assert_eq!(
+        old_doc.document["testDescription"], "Test with new",
+        "We should get the old document under the 'old' property"
+    );
 
     let header = result.header.unwrap();
     assert_eq!(header._id.is_empty(), false);
@@ -276,9 +314,21 @@ async fn test_post_create_document_3_7() {
 
     let result = update.unwrap();
 
-    assert_eq!(result.old.is_none(), true);
-    assert_eq!(result.new.is_none(), true);
-    assert_eq!(result.header.is_none(), true);
+    assert_eq!(
+        result.old.is_none(),
+        true,
+        "silent mode should not return old document"
+    );
+    assert_eq!(
+        result.new.is_none(),
+        true,
+        "silent mode should not return new document"
+    );
+    assert_eq!(
+        result.header.is_none(),
+        true,
+        "silent mode should not return header"
+    );
 
     // Fifth test is about the overwrite _mode option ignore
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
@@ -326,7 +376,11 @@ async fn test_post_create_document_3_7() {
 
     let result = update.unwrap();
     assert_eq!(result.old.is_none(), true);
-    assert_eq!(result.new.is_none(), false);
+    assert_eq!(
+        result.new.is_none(),
+        false,
+        "we should get the new document when we use the overwriteMode = 'replace'"
+    );
 
     let doc = result.new.unwrap();
     assert_eq!(doc.document["no"], 3);
@@ -423,7 +477,7 @@ async fn test_get_read_document() {
         .await;
     // We should get a 412, for now for some reason the error is parsed as a document
     // todo fix how the reponse/error is built
-    assert_eq!(read.is_err(), true, " we should get 412");
+    assert_eq!(read.is_err(), true, "we should get 412, got: {:?}", read);
 
     // todo need to test with with IfNoneMatch and 304
 
@@ -471,8 +525,15 @@ async fn test_get_read_document_header() {
     let _rev = header._rev;
 
     let read = coll.read_document_header(_key.as_str()).await;
+
+    assert_eq!(read.is_ok(), true, "We should get 200, got {:?}", read);
+
     let result = read.unwrap();
-    assert_eq!(result._key, _key);
+    assert_eq!(
+        result._key, _key,
+        "We should got the key of the document  : {:?}",
+        result._key
+    );
 
     let read = coll
         .read_document_header_with_options(

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -809,12 +809,8 @@ async fn test_delete_remove_document() {
     let remove = coll
         .remove_document(
             _key.as_str(),
-            Some(DocumentRemoveOptions {
-                wait_for_sync: None,
-                return_old: Some(true),
-                silent: None,
-                if_match: None,
-            }),
+            Some(DocumentRemoveOptions::builder().return_old(true).build()),
+            None,
         )
         .await;
 
@@ -848,12 +844,8 @@ async fn test_delete_remove_document() {
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),
-            Some(DocumentRemoveOptions {
-                wait_for_sync: None,
-                return_old: None,
-                silent: Some(true),
-                if_match: None,
-            }),
+            Some(DocumentRemoveOptions::builder().silent(true).build()),
+            None,
         )
         .await;
 
@@ -878,15 +870,7 @@ async fn test_delete_remove_document() {
     let _key = header._key;
     let _rev = header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
-        .remove_document(
-            _key.as_str(),
-            Some(DocumentRemoveOptions {
-                wait_for_sync: None,
-                return_old: None,
-                silent: None,
-                if_match: Some("_rere_dsds_DSds".to_string()),
-            }),
-        )
+        .remove_document(_key.as_str(), None, Some("_rere_dsds_DSds".to_string()))
         .await;
 
     assert_eq!(
@@ -897,31 +881,13 @@ async fn test_delete_remove_document() {
     );
     // Fourth test to check that we get error if we tried to remove a doc that has
     // already been removed or that does not exist
-    let remove: Result<DocumentResponse<Value>, ClientError> = coll
-        .remove_document(
-            _key.as_str(),
-            Some(DocumentRemoveOptions {
-                wait_for_sync: None,
-                return_old: None,
-                silent: None,
-                if_match: None,
-            }),
-        )
-        .await;
+    let remove: Result<DocumentResponse<Value>, ClientError> =
+        coll.remove_document(_key.as_str(), None, None).await;
 
     assert_eq!(remove.is_err(), false, "We should remove the doc");
 
-    let remove: Result<DocumentResponse<Value>, ClientError> = coll
-        .remove_document(
-            _key.as_str(),
-            Some(DocumentRemoveOptions {
-                wait_for_sync: None,
-                return_old: None,
-                silent: None,
-                if_match: None,
-            }),
-        )
-        .await;
+    let remove: Result<DocumentResponse<Value>, ClientError> =
+        coll.remove_document(_key.as_str(), None, None).await;
 
     assert_eq!(
         remove.is_err(),

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -50,9 +50,10 @@ async fn test_post_create_document() {
 
     // First test is to create a simple document without options
     let create = coll.create_document(test_doc, None).await;
-    assert_eq!(create.is_ok(), true, "succeed create a document");
 
+    assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
+
     assert_eq!(result.is_silent(), false);
     assert_eq!(result.has_response(), true);
 
@@ -611,7 +612,11 @@ async fn test_patch_update_document() {
     let result = update.unwrap();
     let response = result.get_response().unwrap();
 
-    assert_eq!(response.header.unwrap()._rev != _rev, true);
+    assert_eq!(
+        response.header.unwrap()._rev != _rev,
+        true,
+        "We should get a different revision after update"
+    );
 
     // Test when we do not ignore_revs. W
     let replace = coll
@@ -809,6 +814,7 @@ async fn test_delete_remove_document() {
 
     let result = remove.unwrap();
     let response = result.get_response().unwrap();
+
     assert_eq!(
         response.new.is_none(),
         true,

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -413,17 +413,14 @@ async fn test_get_read_document() {
     assert_eq!(result.document["testDescription"], "read a document");
     // Test if we get the right doc when it does match
     let read: Result<Document<Value>, ClientError> = coll
-        .read_document_with_options(
-            _key.as_str(),
-            Some(DocumentReadOptions::IfMatch(_rev.clone())),
-        )
+        .read_document_with_options(_key.as_str(), DocumentReadOptions::IfMatch(_rev.clone()))
         .await;
     assert_eq!(read.is_err(), false, "got the right document");
     // Test if we get the 412 code response when there is no match
     let read: Result<Document<Value>, ClientError> = coll
         .read_document_with_options(
             _key.as_str(),
-            Some(DocumentReadOptions::IfMatch("_dsdsds_d".to_string())),
+            DocumentReadOptions::IfMatch("_dsdsds_d".to_string()),
         )
         .await;
     // We should get a 412, for now for some reason the error is parsed as a
@@ -500,7 +497,7 @@ async fn test_get_read_document_header() {
     let read = coll
         .read_document_header_with_options(
             _key.as_str(),
-            Some(DocumentReadOptions::IfMatch(_rev.clone())),
+            DocumentReadOptions::IfMatch(_rev.clone()),
         )
         .await;
 
@@ -512,7 +509,7 @@ async fn test_get_read_document_header() {
     let read = coll
         .read_document_header_with_options(
             _key.as_str(),
-            Some(DocumentReadOptions::IfMatch("_dsdsds".to_string())),
+            DocumentReadOptions::IfMatch("_dsdsds".to_string()),
         )
         .await;
 
@@ -524,7 +521,7 @@ async fn test_get_read_document_header() {
     let read = coll
         .read_document_header_with_options(
             _key.as_str(),
-            Some(DocumentReadOptions::IfNoneMatch(_rev.clone())),
+            DocumentReadOptions::IfNoneMatch(_rev.clone()),
         )
         .await;
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -580,12 +580,10 @@ async fn test_patch_update_document() {
         .update_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(
-                DocumentUpdateOptions::builder()
-                    .return_new(true)
-                    .return_old(true)
-                    .build(),
-            ),
+            DocumentUpdateOptions::builder()
+                .return_new(true)
+                .return_old(true)
+                .build(),
         )
         .await;
 
@@ -602,7 +600,7 @@ async fn test_patch_update_document() {
 
     let _rev = response.header._rev;
     let update = coll
-        .update_document(_key.as_str(), json!({ "no":3}), None)
+        .update_document(_key.as_str(), json!({ "no":3}), Default::default())
         .await;
 
     let result = update.unwrap();
@@ -619,7 +617,7 @@ async fn test_patch_update_document() {
         .update_document(
             _key.as_str(),
             json!({ "no":2 , "_rev" :"_dsds_dsds_dsds_" }),
-            Some(DocumentUpdateOptions::builder().ignore_revs(false).build()),
+            DocumentUpdateOptions::builder().ignore_revs(false).build(),
         )
         .await;
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -583,15 +583,12 @@ async fn test_patch_update_document() {
         .update_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(DocumentUpdateOptions {
-                keep_null: None,
-                merge_objects: None,
-                wait_for_sync: None,
-                ignore_revs: None,
-                return_new: Some(true),
-                return_old: Some(true),
-                silent: None,
-            }),
+            Some(
+                DocumentUpdateOptions::builder()
+                    .return_new(true)
+                    .return_old(true)
+                    .build(),
+            ),
         )
         .await;
 
@@ -608,19 +605,7 @@ async fn test_patch_update_document() {
 
     let _rev = result.header.unwrap()._rev;
     let update = coll
-        .update_document(
-            _key.as_str(),
-            json!({ "no":3}),
-            Some(DocumentUpdateOptions {
-                keep_null: None,
-                merge_objects: None,
-                wait_for_sync: None,
-                ignore_revs: None,
-                return_new: None,
-                return_old: None,
-                silent: None,
-            }),
-        )
+        .update_document(_key.as_str(), json!({ "no":3}), None)
         .await;
 
     let result: DocumentResponse<Value> = update.unwrap();
@@ -632,15 +617,7 @@ async fn test_patch_update_document() {
         .update_document(
             _key.as_str(),
             json!({ "no":2 , "_rev" :"_dsds_dsds_dsds_" }),
-            Some(DocumentUpdateOptions {
-                keep_null: None,
-                merge_objects: None,
-                wait_for_sync: None,
-                ignore_revs: Some(false),
-                return_new: None,
-                return_old: None,
-                silent: None,
-            }),
+            Some(DocumentUpdateOptions::builder().ignore_revs(false).build()),
         )
         .await;
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -5,11 +5,13 @@ use log::trace;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 
-use arangors::document::{
-    DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions, DocumentResponse,
-    DocumentUpdateOptions,
+use arangors::{
+    document::{
+        DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions, DocumentResponse,
+        DocumentUpdateOptions,
+    },
+    ClientError, Connection, Document,
 };
-use arangors::{ClientError, Connection, Document};
 use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup};
 
 pub mod common;
@@ -67,7 +69,8 @@ async fn test_post_create_document() {
         false,
         "We should get the key of the document"
     );
-    // Second test is to create a simple document with option to get the new document back
+    // Second test is to create a simple document with option to get the new
+    // document back
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "testDescription":"Test with new"
     }));
@@ -104,8 +107,8 @@ async fn test_post_create_document() {
 
     let key = header._key;
     // Third test is to update a simple document with option return old
-    // Should not return  anything according to doc if overWriteMode is not used for now
-    // TODO update this test with overwriteMode later
+    // Should not return  anything according to doc if overWriteMode is not used for
+    // now TODO update this test with overwriteMode later
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "_key" : key,
     "testDescription":"Test with old"
@@ -220,7 +223,8 @@ async fn test_post_create_document_3_7() {
         false,
         "We should get the key of the document"
     );
-    // Second test is to create a simple document with option to get the new document back
+    // Second test is to create a simple document with option to get the new
+    // document back
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "testDescription":"Test with new"
     }));
@@ -258,8 +262,8 @@ async fn test_post_create_document_3_7() {
 
     let key = header._key;
     // Third test is to update a simple document with option return old
-    // Should not return  anything according to doc if overWriteMode is not used for now
-    // TODO update this test with overwriteMode later
+    // Should not return  anything according to doc if overWriteMode is not used for
+    // now TODO update this test with overwriteMode later
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
     "_key" : key,
     "testDescription":"Test with old"
@@ -473,8 +477,8 @@ async fn test_get_read_document() {
             Some(DocumentReadOptions::IfMatch("_dsdsds_d".to_string())),
         )
         .await;
-    // We should get a 412, for now for some reason the error is parsed as a document
-    // todo fix how the reponse/error is built
+    // We should get a 412, for now for some reason the error is parsed as a
+    // document todo fix how the reponse/error is built
     assert_eq!(read.is_err(), true, "we should get 412, got: {:?}", read);
 
     // todo need to test with with IfNoneMatch and 304

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -978,7 +978,7 @@ async fn test_delete_remove_document() {
         "We should have precondition failed as we ask to move the doc only if for the specified \
          _rev in header"
     );
-    /// Fourth test to check that we get error if we tried to remove a doc that has already been removed or that does not exist
+    // Fourth test to check that we get error if we tried to remove a doc that has already been removed or that does not exist
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -37,10 +37,9 @@ async fn test_post_create_document() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
-
+    assert_eq!(coll.is_err(), true, "drop collection");
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -186,7 +185,7 @@ async fn test_post_create_document_3_7() {
     assert_eq!(coll.is_err(), true);
 
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -372,7 +371,7 @@ async fn test_post_create_document_3_7() {
     assert_eq!(response.header.is_none(), false);
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -397,7 +396,7 @@ async fn test_get_read_document() {
     assert_eq!(coll.is_err(), true);
 
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -445,7 +444,7 @@ async fn test_get_read_document() {
     // todo need to test with with IfNoneMatch and 304
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -469,9 +468,10 @@ async fn test_get_read_document_header() {
     let coll = database.drop_collection(collection_name).await;
     assert_eq!(coll.is_err(), true);
 
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), true, "drop collection");
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
-
+    coll.expect("Should create the collection");
     let coll = database.collection(collection_name).await.unwrap();
 
     let test_doc: Document<Value> = Document::new(json!({ "no":1 ,
@@ -540,7 +540,7 @@ async fn test_get_read_document_header() {
         "the If-None-Match header is given and the document has the same version"
     );
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 }
 
 #[maybe_async::test(
@@ -564,8 +564,10 @@ async fn test_patch_update_document() {
     let coll = database.drop_collection(collection_name).await;
     assert_eq!(coll.is_err(), true);
 
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), true, "drop collection");
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -635,7 +637,7 @@ async fn test_patch_update_document() {
     );
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
     // todo do more test for merge objects and stuff
 }
 
@@ -660,8 +662,10 @@ async fn test_post_replace_document() {
     let coll = database.drop_collection(collection_name).await;
     assert_eq!(coll.is_err(), true);
 
+    let coll = database.drop_collection(collection_name).await;
+    assert_eq!(coll.is_err(), true, "drop collection");
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -759,7 +763,7 @@ async fn test_post_replace_document() {
     );
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should drop the collection");
 
     // todo do more test
 }
@@ -783,10 +787,9 @@ async fn test_delete_remove_document() {
     let mut database = conn.db("test_db").await.unwrap();
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), true);
-
+    assert_eq!(coll.is_err(), true, "drop collection");
     let coll = database.create_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
+    coll.expect("Should create the collection");
 
     let coll = database.collection(collection_name).await.unwrap();
 
@@ -889,7 +892,6 @@ async fn test_delete_remove_document() {
     );
 
     let coll = database.drop_collection(collection_name).await;
-    assert_eq!(coll.is_err(), false);
-
+    coll.expect("Should drop the collection");
     // todo do more test
 }

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -79,13 +79,7 @@ async fn test_post_create_document() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: Some(true),
-                return_old: None,
-                silent: None,
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().return_new(true).build()),
         )
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
@@ -117,13 +111,12 @@ async fn test_post_create_document() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: Some(true),
-                silent: None,
-                overwrite: Some(true),
-            }),
+            Some(
+                DocumentInsertOptions::builder()
+                    .return_old(true)
+                    .overwrite(true)
+                    .build(),
+            ),
         )
         .await;
     assert_eq!(update.is_ok(), true, "succeed update a document");
@@ -149,13 +142,7 @@ async fn test_post_create_document() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: None,
-                silent: Some(true),
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().silent(true).build()),
         )
         .await;
 
@@ -233,14 +220,7 @@ async fn test_post_create_document_3_7() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: Some(true),
-                return_old: None,
-                silent: None,
-                overwrite_mode: None,
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().return_new(true).build()),
         )
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
@@ -272,14 +252,12 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: Some(true),
-                silent: None,
-                overwrite_mode: None,
-                overwrite: Some(true),
-            }),
+            Some(
+                DocumentInsertOptions::builder()
+                    .return_old(true)
+                    .overwrite(true)
+                    .build(),
+            ),
         )
         .await;
 
@@ -304,14 +282,7 @@ async fn test_post_create_document_3_7() {
     let create = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: None,
-                silent: Some(true),
-                overwrite_mode: None,
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().silent(true).build()),
         )
         .await;
 
@@ -341,14 +312,11 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: Some(true),
-                return_old: None,
-                silent: None,
-                overwrite_mode: Some(DocumentOverwriteMode::Ignore),
-                overwrite: None,
-            }),
+            Some(
+                DocumentInsertOptions::builder()
+                    .return_new(true)
+                    .overwrite_mode(DocumentOverwriteMode::Ignore),
+            ),
         )
         .await;
 
@@ -366,14 +334,7 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: None,
-                silent: None,
-                overwrite_mode: Some(DocumentOverwriteMode::Replace),
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Replace)),
         )
         .await;
 
@@ -396,14 +357,7 @@ async fn test_post_create_document_3_7() {
     let update = coll
         .create_document(
             test_doc,
-            Some(DocumentInsertOptions {
-                wait_for_sync: None,
-                return_new: None,
-                return_old: None,
-                silent: None,
-                overwrite_mode: Some(DocumentOverwriteMode::Update),
-                overwrite: None,
-            }),
+            Some(DocumentInsertOptions::builder().overwrite_mode(DocumentOverwriteMode::Update)),
         )
         .await;
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -678,12 +678,10 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(
-                DocumentReplaceOptions::builder()
-                    .return_new(true)
-                    .return_old(true)
-                    .build(),
-            ),
+            DocumentReplaceOptions::builder()
+                .return_new(true)
+                .return_old(true)
+                .build(),
             None,
         )
         .await;
@@ -717,7 +715,7 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(DocumentReplaceOptions::builder().silent(true).build()),
+            DocumentReplaceOptions::builder().silent(true).build(),
             None,
         )
         .await;
@@ -728,7 +726,12 @@ async fn test_post_replace_document() {
     // third test tro try out the if-match header
 
     let replace = coll
-        .replace_document(_key.as_str(), json!({ "no":2}), None, Some(_rev.clone()))
+        .replace_document(
+            _key.as_str(),
+            json!({ "no":2}),
+            Default::default(),
+            Some(_rev.clone()),
+        )
         .await;
 
     assert_eq!(
@@ -742,7 +745,7 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2 , "_rev" :_rev.clone() }),
-            Some(DocumentReplaceOptions::builder().ignore_revs(false).build()),
+            DocumentReplaceOptions::builder().ignore_revs(false).build(),
             None,
         )
         .await;

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -480,7 +480,12 @@ async fn test_get_read_document() {
         .await;
     // We should get a 412, for now for some reason the error is parsed as a
     // document todo fix how the reponse/error is built
-    assert_eq!(read.is_err(), true, "we should get 412, got: {:?}", read);
+    assert_eq!(
+        read.is_err(),
+        true,
+        "we should get 412, got: {:?}",
+        read.unwrap().document
+    );
 
     // todo need to test with with IfNoneMatch and 304
 
@@ -529,7 +534,12 @@ async fn test_get_read_document_header() {
 
     let read = coll.read_document_header(_key.as_str()).await;
 
-    assert_eq!(read.is_ok(), true, "We should get 200, got {:?}", read);
+    assert_eq!(
+        read.is_ok(),
+        true,
+        "We should get 200, got {:?}",
+        read.err().unwrap()
+    );
 
     let result = read.unwrap();
     assert_eq!(

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -13,6 +13,7 @@ use arangors::{ClientError, Connection, Document};
 use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup};
 
 pub mod common;
+
 #[cfg(not(feature = "arango3_7"))]
 #[maybe_async::test(
     any(feature = "reqwest_blocking"),

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -56,7 +56,7 @@ async fn test_post_create_document() {
     assert_eq!(result.is_silent(), false);
     assert_eq!(result.has_response(), true);
 
-    let header = result.get_response().unwrap().header.unwrap();
+    let header = result.get_response().unwrap().header;
     assert_eq!(
         header._id.is_empty(),
         false,
@@ -98,7 +98,7 @@ async fn test_post_create_document() {
 
     assert_eq!(doc.document["testDescription"], "Test with new");
 
-    let header = response.header.unwrap();
+    let header = response.header;
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
@@ -134,7 +134,7 @@ async fn test_post_create_document() {
         "We should get the old document under the 'old' property"
     );
 
-    let header = response.header.unwrap();
+    let header = response.header;
 
     assert_eq!(header._id.is_empty(), false,);
     assert_eq!(header._rev.is_empty(), false,);
@@ -200,7 +200,7 @@ async fn test_post_create_document_3_7() {
 
     let result = create.unwrap();
     let response = result.get_response().unwrap();
-    let header = response.header.unwrap();
+    let header = response.header;
     assert_eq!(
         header._id.is_empty(),
         false,
@@ -242,7 +242,7 @@ async fn test_post_create_document_3_7() {
 
     assert_eq!(doc.document["testDescription"], "Test with new");
 
-    let header = response.header.unwrap();
+    let header = response.header;
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
@@ -278,7 +278,7 @@ async fn test_post_create_document_3_7() {
         "We should get the old document under the 'old' property"
     );
 
-    let header = response.header.unwrap();
+    let header = response.header;
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
@@ -408,7 +408,7 @@ async fn test_get_read_document() {
     let create = coll.create_document(test_doc, None).await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
-    let header = create.unwrap().get_response().unwrap().header.unwrap();
+    let header = create.unwrap().get_response().unwrap().header;
     let _key = header._key;
     let _rev = header._rev;
     let read = coll.read_document(_key.as_str()).await;
@@ -483,7 +483,7 @@ async fn test_get_read_document_header() {
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
     let resp = create.unwrap().get_response().unwrap();
-    let header = resp.header.unwrap();
+    let header = resp.header;
     let _key = header._key;
     let _rev = header._rev;
 
@@ -580,7 +580,7 @@ async fn test_patch_update_document() {
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
-    let _key = create.unwrap().get_response().unwrap().header.unwrap()._key;
+    let _key = create.unwrap().get_response().unwrap().header._key;
 
     let update = coll
         .update_document(
@@ -606,7 +606,7 @@ async fn test_patch_update_document() {
     assert_eq!(old_doc["no"], 1);
     assert_eq!(old_doc["testDescription"], "update document");
 
-    let _rev = response.header.unwrap()._rev;
+    let _rev = response.header._rev;
     let update = coll
         .update_document(_key.as_str(), json!({ "no":3}), None)
         .await;
@@ -615,7 +615,7 @@ async fn test_patch_update_document() {
     let response = result.get_response().unwrap();
 
     assert_eq!(
-        response.header.unwrap()._rev != _rev,
+        response.header._rev != _rev,
         true,
         "We should get a different revision after update"
     );
@@ -678,7 +678,7 @@ async fn test_post_replace_document() {
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let response = create.unwrap().get_response().unwrap();
-    let header = response.header.unwrap();
+    let header = response.header;
     let _key = header._key;
     let _rev = header._rev;
 
@@ -803,7 +803,7 @@ async fn test_delete_remove_document() {
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let response = create.unwrap().get_response().unwrap();
-    let header = response.header.unwrap();
+    let header = response.header;
     let _key = header._key;
     let _rev = header._rev;
 
@@ -841,7 +841,7 @@ async fn test_delete_remove_document() {
     }));
     let create = coll.create_document(test_doc, None).await;
     let response = create.unwrap().get_response().unwrap();
-    let header = response.header.unwrap();
+    let header = response.header;
     let _key = header._key;
     let _rev = header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
@@ -862,7 +862,7 @@ async fn test_delete_remove_document() {
     }));
     let create = coll.create_document(test_doc, None).await;
     let response = create.unwrap().get_response().unwrap();
-    let header = response.header.unwrap();
+    let header = response.header;
     let _key = header._key;
     let _rev = header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -5,11 +5,10 @@ use log::trace;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 
-use arangors::document::DocumentReplaceOptions;
 use arangors::{
     document::{
-        DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions, DocumentResponse,
-        DocumentUpdateOptions,
+        DocumentInsertOptions, DocumentOverwriteMode, DocumentReadOptions, DocumentReplaceOptions,
+        DocumentResponse, DocumentUpdateOptions,
     },
     ClientError, Connection, Document,
 };
@@ -684,7 +683,8 @@ async fn test_patch_update_document() {
     assert_eq!(
         replace.is_err(),
         true,
-        "We should have precondition failed as we ask to replace the doc only if for the specified _rev in body"
+        "We should have precondition failed as we ask to replace the doc only if for the \
+         specified _rev in body"
     );
 
     let coll = database.drop_collection(collection_name).await;
@@ -751,7 +751,12 @@ async fn test_post_replace_document() {
     let new_doc: Value = result.new.unwrap();
 
     assert_eq!(new_doc["no"], 2, "We should get the property updated");
-    assert_eq!(new_doc["testDescription"].as_str().is_some(), false, "We should get the property removed sience we did replace the original object with an object that do not have it");
+    assert_eq!(
+        new_doc["testDescription"].as_str().is_some(),
+        false,
+        "We should get the property removed sience we did replace the original object with an \
+         object that do not have it"
+    );
 
     let old_doc: Value = result.old.unwrap();
 
@@ -813,7 +818,8 @@ async fn test_post_replace_document() {
     assert_eq!(
         replace.is_err(),
         true,
-        "We should have precondition failed as we ask to replace the doc only if for the specified _rev in header"
+        "We should have precondition failed as we ask to replace the doc only if for the \
+         specified _rev in header"
     );
 
     let replace = coll
@@ -834,7 +840,8 @@ async fn test_post_replace_document() {
     assert_eq!(
         replace.is_err(),
         true,
-        "We should have precondition failed as we ask to replace the doc only if for the specified _rev in body"
+        "We should have precondition failed as we ask to replace the doc only if for the \
+         specified _rev in body"
     );
 
     let coll = database.drop_collection(collection_name).await;

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -140,10 +140,9 @@ async fn test_post_create_document() {
 
     // Fourth testis about the silent option
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
-    "_key" : key,
     "testDescription":"Test with silent"
     }));
-    let update = coll
+    let create = coll
         .create_document(
             test_doc,
             Some(DocumentInsertOptions {
@@ -156,9 +155,9 @@ async fn test_post_create_document() {
         )
         .await;
 
-    assert_eq!(update.is_ok(), true, "succeed create a document silently");
+    assert_eq!(create.is_ok(), true, "succeed create a document silently");
 
-    let result = update.unwrap();
+    let result = create.unwrap();
 
     assert_eq!(result.old.is_none(), true);
     assert_eq!(result.new.is_none(), true);
@@ -295,10 +294,9 @@ async fn test_post_create_document_3_7() {
 
     // Fourth testis about the silent option
     let test_doc: Document<Value> = Document::new(json!({ "no":2 ,
-    "_key" : key,
     "testDescription":"Test with silent"
     }));
-    let update = coll
+    let create = coll
         .create_document(
             test_doc,
             Some(DocumentInsertOptions {
@@ -312,7 +310,7 @@ async fn test_post_create_document_3_7() {
         )
         .await;
 
-    let result = update.unwrap();
+    let result = create.unwrap();
 
     assert_eq!(
         result.old.is_none(),
@@ -567,7 +565,7 @@ async fn test_get_read_document_header() {
         .await;
 
     assert_eq!(
-        read.is_ok(),
+        read.is_err(),
         true,
         "the If-None-Match header is given and the document has the same version"
     );

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -676,14 +676,13 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(DocumentReplaceOptions {
-                wait_for_sync: None,
-                ignore_revs: None,
-                return_new: Some(true),
-                return_old: Some(true),
-                silent: None,
-                if_match: None,
-            }),
+            Some(
+                DocumentReplaceOptions::builder()
+                    .return_new(true)
+                    .return_old(true)
+                    .build(),
+            ),
+            None,
         )
         .await;
 
@@ -716,14 +715,8 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2}),
-            Some(DocumentReplaceOptions {
-                wait_for_sync: None,
-                ignore_revs: None,
-                return_new: None,
-                return_old: None,
-                silent: Some(true),
-                if_match: None,
-            }),
+            Some(DocumentReplaceOptions::builder().silent(true).build()),
+            None,
         )
         .await;
 
@@ -739,27 +732,16 @@ async fn test_post_replace_document() {
         true,
         "We should not get the old doc back"
     );
-    // Second test to try out the silence mode
+    // third test tro try out the if-match header
 
     let replace = coll
-        .replace_document(
-            _key.as_str(),
-            json!({ "no":2}),
-            Some(DocumentReplaceOptions {
-                wait_for_sync: None,
-                ignore_revs: None,
-                return_new: None,
-                return_old: None,
-                silent: None,
-                if_match: Some(_rev.clone()),
-            }),
-        )
+        .replace_document(_key.as_str(), json!({ "no":2}), None, Some(_rev.clone()))
         .await;
 
     assert_eq!(
         replace.is_err(),
         true,
-        "We should have precondition failed as we ask to replace the doc only if for the \
+        "We should have precondition failed as we ask to replace the doc only if match the \
          specified _rev in header"
     );
 
@@ -767,21 +749,15 @@ async fn test_post_replace_document() {
         .replace_document(
             _key.as_str(),
             json!({ "no":2 , "_rev" :_rev.clone() }),
-            Some(DocumentReplaceOptions {
-                wait_for_sync: None,
-                ignore_revs: Some(false),
-                return_new: None,
-                return_old: None,
-                silent: None,
-                if_match: None,
-            }),
+            Some(DocumentReplaceOptions::builder().ignore_revs(false).build()),
+            None,
         )
         .await;
 
     assert_eq!(
         replace.is_err(),
         true,
-        "We should have precondition failed as we ask to replace the doc only if for the \
+        "We should have precondition failed as we ask to replace the doc only if match the \
          specified _rev in body"
     );
 

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -56,7 +56,7 @@ async fn test_post_create_document() {
     assert_eq!(result.is_silent(), false);
     assert_eq!(result.has_response(), true);
 
-    let header = result.get_response().unwrap().header;
+    let header = result.header().unwrap();
     assert_eq!(
         header._id.is_empty(),
         false,
@@ -86,24 +86,23 @@ async fn test_post_create_document() {
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
-    let response = result.get_response().unwrap();
 
     assert_eq!(
-        response.new.is_some(),
+        result.new_doc().is_some(),
         true,
         "We should get the new document under the 'new' property"
     );
 
-    let doc = response.new.unwrap();
+    let doc = result.new_doc().unwrap();
 
     assert_eq!(doc.document["testDescription"], "Test with new");
 
-    let header = response.header;
+    let header = result.header().unwrap();
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
 
-    let key = header._key;
+    let key = &header._key;
     // Third test is to update a simple document with option return old
     // Should not return  anything according to doc if overWriteMode is not used for
     // now TODO update this test with overwriteMode later
@@ -122,17 +121,16 @@ async fn test_post_create_document() {
         .await;
     assert_eq!(update.is_ok(), true, "succeed update a document");
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
 
-    assert_eq!(response.old.is_some(), true);
+    assert_eq!(result.old_doc().is_some(), true);
 
-    let old_doc = response.old.unwrap();
+    let old_doc = result.old_doc().unwrap();
     assert_eq!(
         old_doc.document["testDescription"], "Test with new",
         "We should get the old document under the 'old' property"
     );
 
-    let header = response.header;
+    let header = result.header().unwrap();
 
     assert_eq!(header._id.is_empty(), false,);
     assert_eq!(header._rev.is_empty(), false,);
@@ -197,8 +195,8 @@ async fn test_post_create_document_3_7() {
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
     let result = create.unwrap();
-    let response = result.get_response().unwrap();
-    let header = response.header;
+
+    let header = result.header().unwrap();
     assert_eq!(
         header._id.is_empty(),
         false,
@@ -228,19 +226,18 @@ async fn test_post_create_document_3_7() {
         .await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
     let result = create.unwrap();
-    let response = result.get_response().unwrap();
 
     assert_eq!(
-        response.new.is_some(),
+        result.return_new().is_some(),
         true,
         "we should get the new document under 'new' property"
     );
 
-    let doc = response.new.unwrap();
+    let doc = result.new_doc().unwrap();
 
     assert_eq!(doc.document["testDescription"], "Test with new");
 
-    let header = response.header;
+    let header = result.header().unwrap();
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
@@ -264,17 +261,16 @@ async fn test_post_create_document_3_7() {
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
 
-    assert_eq!(response.old.is_some(), true);
+    assert_eq!(result.old_doc().is_some(), true);
 
-    let old_doc = response.old.unwrap();
+    let old_doc = result.old_doc().unwrap();
     assert_eq!(
         old_doc.document["testDescription"], "Test with new",
         "We should get the old document under the 'old' property"
     );
 
-    let header = response.header;
+    let header = result.header().unwrap();
     assert_eq!(header._id.is_empty(), false);
     assert_eq!(header._rev.is_empty(), false);
     assert_eq!(header._key.is_empty(), false);
@@ -312,10 +308,10 @@ async fn test_post_create_document_3_7() {
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
-    assert_eq!(response.old.is_none(), true);
-    assert_eq!(response.new.is_none(), true);
-    assert_eq!(response.header.is_none(), true);
+
+    assert_eq!(result.new_doc().is_none(), true);
+    assert_eq!(result.old_doc().is_none(), true);
+    assert_eq!(result.header().is_none(), true);
 
     // Sixth test is about the overwrite _mode option replace
     let test_doc: Document<Value> = Document::new(json!({ "no":3 ,
@@ -330,18 +326,18 @@ async fn test_post_create_document_3_7() {
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
-    assert_eq!(response.old.is_none(), true);
+
+    assert_eq!(result.old_doc().is_none(), true);
     assert_eq!(
-        response.new.is_none(),
+        result.new_doc().is_none(),
         false,
         "we should get the new document when we use the overwriteMode = 'replace'"
     );
 
-    let doc = response.new.unwrap();
+    let doc = result.new_doc().unwrap();
     assert_eq!(doc.document["no"], 3);
 
-    assert_eq!(response.header.is_none(), false);
+    assert_eq!(result.header().is_none(), false);
     // Seventh test is about the overwrite _mode option update
     let test_doc: Document<Value> = Document::new(json!({ "no":4 ,
     "_key" : key,
@@ -354,15 +350,14 @@ async fn test_post_create_document_3_7() {
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
 
-    assert_eq!(response.old.is_none(), true);
-    assert_eq!(response.new.is_none(), false);
+    assert_eq!(result.old_doc().is_none(), true);
+    assert_eq!(result.new_doc().is_none(), false);
 
-    let doc = response.new.unwrap();
+    let doc = result.new_doc().unwrap();
     assert_eq!(doc.document["no"], 4);
 
-    assert_eq!(response.header.is_none(), false);
+    assert_eq!(result.header().is_none(), false);
 
     let coll = database.drop_collection(collection_name).await;
     coll.expect("Should drop the collection");
@@ -401,10 +396,10 @@ async fn test_get_read_document() {
     // First test is to read a simple document without options
     let create = coll.create_document(test_doc, Default::default()).await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
-
-    let header = create.unwrap().get_response().unwrap().header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
     let read = coll.read_document(_key.as_str()).await;
 
     let result: Document<Value> = read.unwrap();
@@ -473,10 +468,10 @@ async fn test_get_read_document_header() {
     let create = coll.create_document(test_doc, Default::default()).await;
     assert_eq!(create.is_ok(), true, "succeed create a document");
 
-    let resp = create.unwrap().get_response().unwrap();
-    let header = resp.header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
 
     let read = coll.read_document_header(_key.as_str()).await;
 
@@ -489,7 +484,8 @@ async fn test_get_read_document_header() {
 
     let result = read.unwrap();
     assert_eq!(
-        result._key, _key,
+        result._key,
+        _key.to_string(),
         "We should got the key of the document  : {:?}",
         result._key
     );
@@ -504,7 +500,12 @@ async fn test_get_read_document_header() {
     assert_eq!(read.is_ok(), true, "We should have the right header");
 
     let result = read.unwrap();
-    assert_eq!(result._key, _key,);
+    assert_eq!(
+        result._key,
+        _key.to_string(),
+        "We should have the right key, instead got {:?}",
+        result._key
+    );
 
     let read = coll
         .read_document_header_with_options(
@@ -570,8 +571,9 @@ async fn test_patch_update_document() {
     let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
-
-    let _key = create.unwrap().get_response().unwrap().header._key;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
 
     let update = coll
         .update_document(
@@ -585,26 +587,24 @@ async fn test_patch_update_document() {
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
-    let new_doc = response.new.unwrap();
-    let old_doc = response.old.unwrap();
+
+    let new_doc = result.new_doc().unwrap();
+    let old_doc = result.old_doc().unwrap();
 
     assert_eq!(new_doc["no"], 2);
     assert_eq!(new_doc["testDescription"], "update document");
 
     assert_eq!(old_doc["no"], 1);
     assert_eq!(old_doc["testDescription"], "update document");
-
-    let _rev = response.header._rev;
+    let header = result.header().unwrap();
+    let _rev = &header._rev;
     let update = coll
         .update_document(_key.as_str(), json!({ "no":3}), Default::default())
         .await;
 
     let result = update.unwrap();
-    let response = result.get_response().unwrap();
-
     assert_eq!(
-        response.header._rev != _rev,
+        result.header().unwrap()._rev != _rev.to_string(),
         true,
         "We should get a different revision after update"
     );
@@ -666,10 +666,10 @@ async fn test_post_replace_document() {
     let create = coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
-    let response = create.unwrap().get_response().unwrap();
-    let header = response.header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
 
     let replace = coll
         .replace_document(
@@ -684,18 +684,18 @@ async fn test_post_replace_document() {
         .await;
 
     let result = replace.unwrap();
-    let response = result.get_response().unwrap();
-    let new_doc: Value = response.new.unwrap();
+
+    let new_doc = result.new_doc().unwrap();
 
     assert_eq!(new_doc["no"], 2, "We should get the property updated");
     assert_eq!(
         new_doc["testDescription"].as_str().is_some(),
         false,
-        "We should get the property removed sience we did replace the original object with an \
+        "We should get the property removed since we did replace the original object with an \
          object that do not have it"
     );
 
-    let old_doc: Value = response.old.unwrap();
+    let old_doc = result.old_doc().unwrap();
 
     assert_eq!(
         old_doc["no"], 1,
@@ -794,10 +794,10 @@ async fn test_delete_remove_document() {
         coll.create_document(test_doc, Default::default()).await;
 
     assert_eq!(create.is_ok(), true, "succeed create a document");
-    let response = create.unwrap().get_response().unwrap();
-    let header = response.header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
 
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
@@ -808,15 +808,14 @@ async fn test_delete_remove_document() {
         .await;
 
     let result = remove.unwrap();
-    let response = result.get_response().unwrap();
 
     assert_eq!(
-        response.new.is_none(),
+        result.new_doc().is_none(),
         true,
         "we should never have new doc returned when using remove document"
     );
 
-    let old_doc: Value = response.old.unwrap();
+    let old_doc = result.old_doc().unwrap();
 
     assert_eq!(
         old_doc["no"], 1,
@@ -832,10 +831,10 @@ async fn test_delete_remove_document() {
     "testDescription":"update document"
     }));
     let create = coll.create_document(test_doc, Default::default()).await;
-    let response = create.unwrap().get_response().unwrap();
-    let header = response.header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),
@@ -853,10 +852,10 @@ async fn test_delete_remove_document() {
     "testDescription":"update document"
     }));
     let create = coll.create_document(test_doc, Default::default()).await;
-    let response = create.unwrap().get_response().unwrap();
-    let header = response.header;
-    let _key = header._key;
-    let _rev = header._rev;
+    let result = create.unwrap();
+    let header = result.header().unwrap();
+    let _key = &header._key;
+    let _rev = &header._rev;
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -978,7 +978,8 @@ async fn test_delete_remove_document() {
         "We should have precondition failed as we ask to move the doc only if for the specified \
          _rev in header"
     );
-    // Fourth test to check that we get error if we tried to remove a doc that has already been removed or that does not exist
+    // Fourth test to check that we get error if we tried to remove a doc that has
+    // already been removed or that does not exist
     let remove: Result<DocumentResponse<Value>, ClientError> = coll
         .remove_document(
             _key.as_str(),


### PR DESCRIPTION
Hey ! Let's implement from the [Arangodb documentation -> Working with a Document](https://www.arangodb.com/docs/stable/http/document-working-with-documents.html)

- [x] read a single document

- [x] read document header

- [x] create document 

- [x] replace document

- [x] update document


- [x] removes a document


From our work on documents we saw the need for updating some of the existing code regarding request and response. Therefore the todolist for this PR gets also updated

- [x] update how we do request to the server to have more flexibility for adding headers and other options on a request

- [x] update how we handle response from the server


Same as previously, each item is implemented with code and unit test :) 

I see that I got some previous commits. No worries. I ll hard push on my branch later when stuff will be ready.

Let's go !

