### PR TITLE
Remove lifetimes from Database and Collection

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -38,27 +38,26 @@ pub mod response;
 /// that is specified by the user when the collection is created. There are
 /// currently two types: document and edge. The default type is document.
 #[derive(Debug, Clone)]
-pub struct Collection<'a, C: ClientExt> {
+pub struct Collection<C: ClientExt> {
     id: String,
     name: String,
     collection_type: CollectionType,
     base_url: Url,
     document_base_url: Url,
     session: Arc<C>,
-    phantom: &'a (),
 }
 
-impl<'a, C: ClientExt> Collection<'a, C> {
+impl<'a, C: ClientExt> Collection<C> {
     /// Construct Collection given collection info from server
     ///
     /// Base url should be like `http://server:port/_db/mydb/_api/collection/{collection-name}`
     /// Document root should be like: http://server:port/_db/mydb/_api/document/
     pub(crate) fn new<T: Into<String>>(
-        database: &Database<'a, C>,
+        database: &Database<C>,
         name: T,
         id: T,
         collection_type: CollectionType,
-    ) -> Collection<'a, C> {
+    ) -> Collection<C> {
         let name = name.into();
         let path = format!("_api/collection/{}/", &name);
         let url = database.url().join(&path).unwrap();
@@ -71,14 +70,10 @@ impl<'a, C: ClientExt> Collection<'a, C> {
             base_url: url,
             document_base_url,
             collection_type,
-            phantom: &(*database.phantom),
         }
     }
 
-    pub(crate) fn from_response(
-        database: &Database<'a, C>,
-        collection: &Info,
-    ) -> Collection<'a, C> {
+    pub(crate) fn from_response(database: &Database<C>, collection: &Info) -> Collection<C> {
         Self::new(
             database,
             collection.name.to_owned(),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -144,7 +144,7 @@ impl<S, C: ClientExt> GenericConnection<C, S> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn db(&self, name: &str) -> Result<Database<'_, C>, ClientError> {
+    pub async fn db(&self, name: &str) -> Result<Database<C>, ClientError> {
         let db = Database::new(&self, name);
         db.info().await?;
         Ok(db)
@@ -358,7 +358,7 @@ impl<C: ClientExt> GenericConnection<C, Normal> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn create_database(&self, name: &str) -> Result<Database<'_, C>, ClientError> {
+    pub async fn create_database(&self, name: &str) -> Result<Database<C>, ClientError> {
         let mut map = HashMap::new();
         map.insert("name", name);
         let url = self.arango_url.join("/_api/database").unwrap();

--- a/src/database.rs
+++ b/src/database.rs
@@ -24,14 +24,13 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct Database<'a, C: ClientExt> {
+pub struct Database<C: ClientExt> {
     name: String,
     base_url: Url,
     session: Arc<C>,
-    pub(crate) phantom: &'a (),
 }
 
-impl<'a, C: ClientExt> Database<'a, C> {
+impl<'a, C: ClientExt> Database<C> {
     pub(crate) fn new<T: Into<String>, S>(
         conn: &'a GenericConnection<C, S>,
         name: T,
@@ -43,7 +42,6 @@ impl<'a, C: ClientExt> Database<'a, C> {
             name,
             session: conn.session(),
             base_url: url,
-            phantom: &conn.phantom,
         }
     }
     /// Retrieve all collections of this database.
@@ -81,7 +79,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn collection(&self, name: &str) -> Result<Collection<'a, C>, ClientError> {
+    pub async fn collection(&self, name: &str) -> Result<Collection<C>, ClientError> {
         let url = self
             .base_url
             .join(&format!("_api/collection/{}", name))
@@ -101,7 +99,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
         &self,
         options: CreateOptions<'f>,
         parameters: CreateParameters,
-    ) -> Result<Collection<'_, C>, ClientError> {
+    ) -> Result<Collection<C>, ClientError> {
         let mut url = self.base_url.join("_api/collection").unwrap();
         let query = serde_qs::to_string(&parameters).unwrap();
         url.set_query(Some(query.as_str()));
@@ -121,7 +119,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
     /// # Note
     /// this function would make a request to arango server.
     #[maybe_async]
-    pub async fn create_collection(&self, name: &str) -> Result<Collection<'_, C>, ClientError> {
+    pub async fn create_collection(&self, name: &str) -> Result<Collection<C>, ClientError> {
         self.create_collection_with_options(
             CreateOptions::builder().name(name).build(),
             Default::default(),
@@ -130,10 +128,7 @@ impl<'a, C: ClientExt> Database<'a, C> {
     }
 
     #[maybe_async]
-    pub async fn create_edge_collection(
-        &self,
-        name: &str,
-    ) -> Result<Collection<'_, C>, ClientError> {
+    pub async fn create_edge_collection(&self, name: &str) -> Result<Collection<C>, ClientError> {
         self.create_collection_with_options(
             CreateOptions::builder()
                 .name(name)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -59,7 +59,7 @@ pub async fn connection() -> arangors::Connection {
 pub async fn collection<'a>(
     conn: &'a arangors::Connection,
     name: &str,
-) -> Collection<'a, arangors::client::reqwest::ReqwestClient> {
+) -> Collection<arangors::client::reqwest::ReqwestClient> {
     let mut database = conn.db("test_db").await.unwrap();
 
     match database.drop_collection(name).await {
@@ -77,7 +77,7 @@ pub async fn collection<'a>(
 pub async fn collection<'a>(
     conn: &'a arangors::Connection,
     name: &str,
-) -> Collection<'a, arangors::client::surf::SurfClient> {
+) -> Collection<arangors::client::surf::SurfClient> {
     let mut database = conn.db("test_db").await.unwrap();
 
     match database.drop_collection(name).await {


### PR DESCRIPTION
Removes the phantom lifetime field from Database and Collection.

These fields apparently do not add any value, and make working with the
API quite a lot more cumbersome.