### PR TITLE
Fix Db::create_edge_collection

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -765,7 +765,9 @@ fn make_header_from_options(
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize)]
 pub enum CollectionType {
+    #[serde(rename = "2")]
     Document = 2,
+    #[serde(rename = "3")]
     Edge = 3,
 }
 

--- a/src/collection/options.rs
+++ b/src/collection/options.rs
@@ -46,7 +46,7 @@ pub struct CreateOptions<'a> {
     name: &'a str,
 
     /// the type of the collection to create
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     collection_type: Option<CollectionType>,
 


### PR DESCRIPTION
Fixes two mistakes:
* CollectionType must serialize to numeric values
* CreateOptions::collection_type field must be `type` for API
