### PR TITLE
Fix bug in fetch-all

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -218,7 +218,6 @@ impl<'a, C: ClientExt> Database<C> {
             .join(&format!("_api/cursor/{}", cursor_id))
             .unwrap();
         let resp = self.session.put(url, "").await?;
-
         deserialize_response(resp.body())
     }
 
@@ -235,6 +234,7 @@ impl<'a, C: ClientExt> Database<C> {
                 results.extend(response_cursor.result.into_iter());
                 response_cursor = self.aql_next_batch(id.as_str()).await?;
             } else {
+                results.extend(response_cursor.result.into_iter());
                 break;
             }
         }


### PR DESCRIPTION
Fetch-all doesn't store the last cursor data, so the results are always
limited to thousands, data fetching is incomplete.