### PR TITLE
Re-export uclient

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,7 @@ pub use crate::{
     document::Document,
     error::{ArangoError, ClientError},
 };
+pub use uclient;
 
 pub mod analyzer;
 pub mod aql;


### PR DESCRIPTION
This allows consumers of `arangors` to use the `ClientExt` trait without the need to manually adding `uclient` as a dependency for just the trait. And i also ensures, that the trait versions are in sync.