### PR TITLE
Proposition of refactoring: "Arangors lite"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
           RUST_LOG: arangors=trace
         with:
           command: check
-          args: --no-default-features --features "rocksdb cluster enterprise blocking" --lib
+          args:  --features "rocksdb cluster enterprise blocking" --lib
 
       - name: test (blocking)
         uses: actions-rs/cargo@v1
@@ -42,24 +42,7 @@ jobs:
         timeout-minutes: 40
         with:
           command: test
-          args: --no-fail-fast --no-default-features --features "rocksdb cluster enterprise blocking" --lib
-
-      - name: check build (reqwest_blocking)
-        uses: actions-rs/cargo@v1
-        env:
-          RUST_LOG: arangors=trace
-        with:
-          command: check
-          args: --no-default-features --features "rocksdb cluster enterprise reqwest_blocking" --all
-
-      - name: test (reqwest_blocking)
-        uses: actions-rs/cargo@v1
-        env:
-          RUST_LOG: arangors=trace
-        timeout-minutes: 40
-        with:
-          command: test
-          args: --no-fail-fast --no-default-features --features "rocksdb cluster enterprise reqwest_blocking" --all
+          args: --no-fail-fast --features "rocksdb cluster enterprise blocking" --lib
 
       - name: check build (default features)
         uses: actions-rs/cargo@v1
@@ -78,56 +61,39 @@ jobs:
           command: test
           args: --all --no-fail-fast -- --nocapture
 
-      - name: check build (async)
+      - name: check build (async rustls)
         uses: actions-rs/cargo@v1
         env:
           RUST_LOG: arangors=trace
         with:
           command: check
-          args: --no-default-features --features "rocksdb cluster enterprise" --lib
+          args: --no-default-features --features "rustls rocksdb cluster enterprise" --lib
 
-      - name: test (async)
+      - name: test (async rustls)
         uses: actions-rs/cargo@v1
         env:
           RUST_LOG: arangors=trace
         timeout-minutes: 40
         with:
           command: test
-          args: --no-fail-fast --no-default-features --features "rocksdb cluster enterprise" --lib
+          args: --no-fail-fast --no-default-features --features "rustls rocksdb cluster enterprise" --lib
 
-      - name: check build (reqwest_async)
+      - name: check build (blocking rustls)
         uses: actions-rs/cargo@v1
         env:
           RUST_LOG: arangors=trace
         with:
           command: check
-          args: --no-default-features --features "rocksdb cluster enterprise reqwest_async" --all
+          args: --no-default-features --features "rustls rocksdb cluster enterprise blocking" --lib
 
-      - name: test (reqwest_async)
+      - name: test (blocking rustls)
         uses: actions-rs/cargo@v1
         env:
           RUST_LOG: arangors=trace
         timeout-minutes: 40
         with:
           command: test
-          args: --no-fail-fast --no-default-features --features "rocksdb cluster enterprise reqwest_async" --all
-
-      - name: check build (surf_async)
-        uses: actions-rs/cargo@v1
-        env:
-          RUST_LOG: arangors=trace
-        with:
-          command: check
-          args: --no-default-features --features "rocksdb cluster enterprise surf_async" --all
-
-      - name: test (surf_async)
-        uses: actions-rs/cargo@v1
-        env:
-          RUST_LOG: arangors=trace
-        timeout-minutes: 40
-        with:
-          command: test
-          args: --no-fail-fast --no-default-features --features "rocksdb cluster enterprise surf_async" --all
+          args: --no-fail-fast --no-default-features --features "rustls rocksdb cluster enterprise blocking" --lib
 
   mmfiles:
 
@@ -151,7 +117,7 @@ jobs:
           RUST_LOG: arangors=trace
         with:
           command: check
-          args: --all --bins --examples --tests --no-default-features --features "mmfiles cluster enterprise reqwest_blocking" --lib
+          args: --all --bins --examples --tests --features "mmfiles cluster enterprise blocking" --lib
 
       - name: tests
         uses: actions-rs/cargo@v1
@@ -160,7 +126,7 @@ jobs:
         timeout-minutes: 40
         with:
           command: test
-          args: --all --no-fail-fast --no-default-features --features "mmfiles cluster enterprise reqwest_blocking"
+          args: --all --no-fail-fast --features "mmfiles cluster enterprise blocking"
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,10 @@ features = [ "rocksdb", "reqwest_async" ]
 status = "actively-developed"
 
 [features]
-default = [ "rocksdb", "reqwest_async" ]
-blocking = [ "maybe-async/is_sync", "uclient/blocking" ]
-reqwest_async = [ "uclient/async_reqwest" ]
-reqwest_async_rustls = [ "uclient/async_reqwest_rustls" ]
-reqwest_blocking = [ "uclient/blocking_reqwest", "blocking" ]
-reqwest_blocking_rustls = [ "uclient/blocking_reqwest_rustls", "blocking" ]
-surf_async = [ "uclient/async_surf", "http-types" ]
+default = [ "rocksdb", "openssl" ]
+blocking = [ "maybe-async/is_sync", "reqwest/blocking" ]
+openssl = [ "reqwest/default-tls" ]
+rustls = [ "reqwest/rustls" ]
 cluster = [ ]
 enterprise = [ ]
 mmfiles = [ ]
@@ -43,7 +40,7 @@ serde_qs = "0.8"
 thiserror = "1"
 typed-builder = "0.9.1"
 url = "2"
-uclient = "0.1"
+futures = "0.3"
 
   [dependencies.serde]
   version = "1"
@@ -51,16 +48,8 @@ uclient = "0.1"
 
   [dependencies.reqwest]
   version = "0.11"
-  features = [ "gzip", "json" ]
-  optional = true
-
-  [dependencies.surf]
-  version = "2"
-  optional = true
-
-  [dependencies.http-types]
-  version = "2.10"
-  optional = true
+  features = [ "gzip", "json", "stream" ]
+  default_features = false
 
 [dev-dependencies]
 env_logger = "0.9"
@@ -71,10 +60,3 @@ anyhow = "1"
   [dev-dependencies.tokio]
   version = "1"
   features = [ "macros", "rt-multi-thread" ]
-
-  [dev-dependencies.async-std]
-  version = "1"
-  features = [ "attributes" ]
-
-  [dev-dependencies.reqwest]
-  version = "0.11"

--- a/README.md
+++ b/README.md
@@ -84,30 +84,30 @@ the Client yourself (see examples).
 Currently out-of-box supported ecosystem are:
 - `reqwest_async`
 - `reqwest_blocking`
-- `surf_async`
 
 By default, `arangors` use `reqwest_async` as underling HTTP Client to
-connect with ArangoDB. You can switch other ecosystem in feature gate:
-
-```toml
-[dependencies]
-arangors = { version = "0.4", features = ["surf_async"], default-features = false }
-```
-
-Or if you want to stick with other ecosystem that are not listed in the
-feature gate, you can get vanilla `arangors` without any HTTP client
-dependency:
+connect with ArangoDB.
 
 ```toml
 [dependencies]
 ## This one is async
-arangors = { version = "0.4", default-features = false }
+arangors = { version = "0.4" }
 ## This one is synchronous
-arangors = { version = "0.4", features = ["blocking"], default-features = false }
+arangors = { version = "0.4", features = ["blocking"] }
 ```
 
 Thanks to `maybe_async`, `arangors` can unify sync and async API and toggle
 with a feature gate. Arangors adopts async first policy.
+
+By default `reqwest` uses OpenSSL. To use `rustls` you may disable default features and use the `rustls` feature:
+
+```toml
+[dependencies]
+## This one uses openssl
+arangors = { version = "0.4" }
+## This one rustls
+arangors = { version = "0.4", features = ["rustls"], default-features = false }
+```
 
 ### Connection
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -51,7 +51,7 @@ pub struct Collection {
     session: Arc<ReqwestClient>,
 }
 
-impl<'a> Collection {
+impl Collection {
     /// Construct Collection given collection info from server
     ///
     /// Base url should be like `http://server:port/_db/mydb/_api/collection/{collection-name}`

--- a/src/connection/client.rs
+++ b/src/connection/client.rs
@@ -1,0 +1,280 @@
+#[cfg(feature = "blocking")]
+use reqwest::blocking::Client;
+#[cfg(not(feature = "blocking"))]
+use reqwest::Client;
+
+use crate::error::HttpError;
+use crate::ClientError;
+use http::header::HeaderMap;
+use http::request::Parts;
+use http::{Request, Response};
+use reqwest::redirect::Policy;
+use std::io::{BufReader, Read};
+
+#[derive(Debug, Clone)]
+pub struct ReqwestClient {
+    pub client: Client,
+    headers: HeaderMap,
+}
+
+impl ReqwestClient {
+    pub fn with_client(
+        client: Client,
+        headers: impl Into<Option<HeaderMap>>,
+    ) -> Result<Self, ClientError> {
+        let headers = match headers.into() {
+            Some(h) => h,
+            None => HeaderMap::new(),
+        };
+        Ok(Self { client, headers })
+    }
+
+    pub fn new(headers: impl Into<Option<HeaderMap>>) -> Result<Self, ClientError> {
+        let client = Client::builder().gzip(true);
+        let headers = match headers.into() {
+            Some(h) => h,
+            None => HeaderMap::new(),
+        };
+
+        client
+            .redirect(Policy::none())
+            .build()
+            .map(|c| ReqwestClient { client: c, headers })
+            .map_err(|e| ClientError::HttpClient(HttpError::HttpClient(format!("{:?}", e))))
+    }
+
+    pub fn headers(&mut self) -> &mut HeaderMap {
+        &mut self.headers
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn get<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::get(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn post<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::post(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn put<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::put(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn delete<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::delete(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn patch<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::patch(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn connect<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::connect(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn head<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::head(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn options<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::options(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    #[inline]
+    pub async fn trace<T>(&self, url: String, text: T) -> Result<Response<String>, ClientError>
+    where
+        T: Into<String> + Send,
+    {
+        self.request(Request::trace(url).body(text.into()).unwrap())
+            .await
+    }
+
+    #[maybe_async::maybe_async]
+    pub async fn request(&self, request: Request<String>) -> Result<Response<String>, ClientError> {
+        self.request_bytes(request.map(|b| b.into_bytes())).await
+    }
+
+    #[maybe_async::maybe_async]
+    pub async fn request_bytes(
+        &self,
+        request: Request<Vec<u8>>,
+    ) -> Result<Response<String>, ClientError> {
+        let req = request.map(|b| BufReader::new(std::io::Cursor::new(b)));
+        let res = self.request_reader(req).await?;
+        Ok(res)
+    }
+
+    #[maybe_async::maybe_async]
+    pub async fn request_reader<T>(
+        &self,
+        mut request: Request<T>,
+    ) -> Result<Response<String>, HttpError>
+    where
+        T: Read + Send + Sync + 'static,
+    {
+        let headers = request.headers_mut();
+        for (header, value) in self.headers.iter() {
+            if !headers.contains_key(header) {
+                headers.insert(header, value.clone());
+            }
+        }
+
+        let req = get_req(request);
+        let resp = self
+            .client
+            .execute(req)
+            .await
+            .map_err(|e| HttpError::HttpClient(format!("{:?}", e)))?;
+
+        let status_code = resp.status();
+        let headers = resp.headers().clone();
+        let version = resp.version();
+        let content = resp
+            .text()
+            .await
+            .map_err(|e| HttpError::HttpClient(format!("{:?}", e)))?;
+        let mut build = http::Response::builder();
+
+        for header in headers.iter() {
+            build = build.header(header.0, header.1);
+        }
+
+        build
+            .status(status_code)
+            .version(version)
+            .body(content)
+            .map_err(|e| HttpError::HttpClient(format!("{:?}", e)))
+    }
+}
+
+#[maybe_async::async_impl]
+fn get_req<T>(req: Request<T>) -> reqwest::Request
+where
+    T: Read + Send + Sync + 'static,
+{
+    use futures::StreamExt;
+    use reqwest::Body;
+
+    let (parts, body) = req.into_parts();
+    let Parts {
+        method,
+        uri,
+        headers,
+        ..
+    } = parts;
+
+    let mut request = reqwest::Request::new(method, uri.to_string().parse().unwrap());
+
+    let mut prev_name = None;
+    for (key, value) in headers {
+        match key {
+            Some(key) => {
+                request.headers_mut().insert(key.clone(), value);
+                prev_name = Some(key);
+            }
+            None => match prev_name {
+                Some(ref key) => {
+                    request.headers_mut().append(key.clone(), value);
+                }
+                None => unreachable!("HeaderMap::into_iter yielded None first"),
+            },
+        }
+    }
+    let body_bytes = body.bytes();
+    let stream = futures::stream::iter(body_bytes).chunks(2048).map(|x| {
+        let len = x.len();
+        let out = x.into_iter().filter_map(|b| b.ok()).collect::<Vec<_>>();
+        if out.len() == len {
+            Ok(out)
+        } else {
+            Err(HttpError::PayloadError)
+        }
+    });
+    request.body_mut().replace(Body::wrap_stream(stream));
+
+    request
+}
+
+#[maybe_async::sync_impl]
+fn get_req<T>(req: Request<T>) -> reqwest::blocking::Request
+where
+    T: Read + Send + Sync + 'static,
+{
+    use reqwest::blocking::Body;
+
+    let (parts, body) = req.into_parts();
+    let Parts {
+        method,
+        uri,
+        headers,
+        ..
+    } = parts;
+    let mut request = reqwest::blocking::Request::new(method, uri.to_string().parse().unwrap());
+
+    let mut prev_name = None;
+    for (key, value) in headers {
+        match key {
+            Some(key) => {
+                request.headers_mut().insert(key.clone(), value);
+                prev_name = Some(key);
+            }
+            None => match prev_name {
+                Some(ref key) => {
+                    request.headers_mut().append(key.clone(), value);
+                }
+                None => unreachable!("HeaderMap::into_iter yielded None first"),
+            },
+        }
+    }
+    request.body_mut().replace(Body::new(body));
+
+    request
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,17 @@ pub enum ClientError {
     #[error("Error from serde: {0}")]
     Serde(#[from] serde_json::error::Error),
     #[error("HTTP client error: {0}")]
-    HttpClient(#[from] uclient::ClientError),
+    HttpClient(#[from] HttpError),
+}
+
+#[derive(Error, Debug)]
+pub enum HttpError {
+    #[error("HTTP client error: {0}")]
+    HttpClient(String),
+    #[error("Invalid file. File not found or permission error")]
+    InvalidFile,
+    #[error("Payload Error")]
+    PayloadError,
 }
 
 #[derive(Deserialize, Debug, Error)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -39,8 +39,7 @@ pub(crate) const INDEX_API_PATH: &str = "_api/index";
 /// # use arangors::Connection;
 /// # use arangors::index::{IndexSettings, Index};
 ///
-/// # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-/// # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+/// # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 /// # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 /// # async fn main() -> Result<(),anyhow::Error>{
 /// # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,7 @@
 //! ```rust
 //! use arangors::Connection;
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! // (Recommended) Handy functions
@@ -149,8 +148,7 @@
 //! ```rust
 //! use arangors::Connection;
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -197,8 +195,7 @@
 //!     pub password: String,
 //! }
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -228,8 +225,7 @@
 //! ```rust
 //! # use arangors::{ClientError,Connection, AqlQuery};
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -289,8 +285,7 @@
 //!     pub password: String,
 //! }
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -319,8 +314,7 @@
 //!     pub password: String,
 //! }
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -353,8 +347,7 @@
 //! use arangors::{AqlQuery, Connection, Cursor, Database};
 //! use serde_json::value::Value;
 //!
-//! # #[cfg_attr(any(feature="reqwest_async"), maybe_async::maybe_async, tokio::main)]
-//! # #[cfg_attr(any(feature="surf_async"), maybe_async::maybe_async, async_std::main)]
+//! # #[cfg_attr(not(feature="blocking"), maybe_async::maybe_async, tokio::main)]
 //! # #[cfg_attr(feature = "blocking", maybe_async::must_be_sync)]
 //! # async fn main() {
 //! # let conn = Connection::establish_jwt("http://localhost:8529", "username", "password")
@@ -383,42 +376,14 @@
 //! `arangors` is provided under the MIT license. See [LICENSE](./LICENSE).
 //! An ergonomic [ArangoDB](https://www.arangodb.com/) client for rust.
 
-#[cfg(all(feature = "reqwest_async", feature = "reqwest_blocking"))]
-compile_error!(
-    r#"feature "reqwest_async" and "reqwest_blocking" cannot be set at the same time.
-If what you want is "reqwest_blocking", please turn off default features by adding "default-features=false" in your Cargo.toml"#
-);
-
-#[cfg(all(feature = "reqwest_async", feature = "surf_async"))]
-compile_error!(
-    r#"feature "reqwest_async" and "surf_async" cannot be set at the same time.
-If what you want is "surf_async", please turn off default features by adding "default-features=false" in your Cargo.toml"#
-);
-
-#[cfg(all(
-    feature = "reqwest_async",
-    feature = "reqwest_blocking",
-    feature = "surf_async"
-))]
-compile_error!(
-    r#"only one of features "reqwest_async", "reqwest_blocking" and "surf_async" can be"#
-);
-#[cfg(any(
-    feature = "reqwest_async",
-    feature = "reqwest_blocking",
-    feature = "surf_async"
-))]
 pub use crate::connection::Connection;
 pub use crate::{
     aql::{AqlOptions, AqlQuery, Cursor},
     collection::Collection,
-    connection::GenericConnection,
     database::Database,
     document::Document,
     error::{ArangoError, ClientError},
 };
-pub use uclient;
-
 pub mod analyzer;
 pub mod aql;
 pub mod collection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,30 +82,30 @@
 //! Currently out-of-box supported ecosystem are:
 //! - `reqwest_async`
 //! - `reqwest_blocking`
-//! - `surf_async`
 //!
 //! By default, `arangors` use `reqwest_async` as underling HTTP Client to
-//! connect with ArangoDB. You can switch other ecosystem in feature gate:
-//!
-//! ```toml
-//! [dependencies]
-//! arangors = { version = "0.4", features = ["surf_async"], default-features = false }
-//! ```
-//!
-//! Or if you want to stick with other ecosystem that are not listed in the
-//! feature gate, you can get vanilla `arangors` without any HTTP client
-//! dependency:
+//! connect with ArangoDB.
 //!
 //! ```toml
 //! [dependencies]
 //! ## This one is async
-//! arangors = { version = "0.4", default-features = false }
+//! arangors = { version = "0.4" }
 //! ## This one is synchronous
-//! arangors = { version = "0.4", features = ["blocking"], default-features = false }
+//! arangors = { version = "0.4", features = ["blocking"] }
 //! ```
 //!
 //! Thanks to `maybe_async`, `arangors` can unify sync and async API and toggle
 //! with a feature gate. Arangors adopts async first policy.
+//!
+//! By default `reqwest` uses OpenSSL. To use `rustls` you may disable default features and use the `rustls` feature:
+//!
+//! ```toml
+//! [dependencies]
+//! ## This one uses openssl
+//! arangors = { version = "0.4" }
+//! ## This one rustls
+//! arangors = { version = "0.4", features = ["rustls"], default-features = false }
+//! ```
 //!
 //! ### Connection
 //!

--- a/tests/analyzer.rs
+++ b/tests/analyzer.rs
@@ -6,7 +6,6 @@ use log::{info, trace};
 use maybe_async::maybe_async;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
-use uclient::ClientExt;
 
 use arangors::analyzer::{
     AnalyzerCase, AnalyzerFeature, AnalyzerInfo, NgramAnalyzerProperties, NgramStreamType,
@@ -26,8 +25,8 @@ use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup
 pub mod common;
 
 #[maybe_async]
-async fn create_norm_analyzer<C: ClientExt>(
-    database: &Database<C>,
+async fn create_norm_analyzer(
+    database: &Database,
     analyzer_name: String,
 ) -> Result<AnalyzerInfo, ClientError> {
     let info = AnalyzerInfo::Norm {
@@ -45,8 +44,8 @@ async fn create_norm_analyzer<C: ClientExt>(
 }
 
 #[maybe_async]
-async fn create_ngram_analyzer<C: ClientExt>(
-    database: &Database<C>,
+async fn create_ngram_analyzer(
+    database: &Database,
     analyzer_name: String,
 ) -> Result<AnalyzerInfo, ClientError> {
     let info = AnalyzerInfo::Ngram {
@@ -66,9 +65,8 @@ async fn create_ngram_analyzer<C: ClientExt>(
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_norm_analyzer() {
     test_setup();
@@ -88,9 +86,8 @@ async fn test_create_and_drop_norm_analyzer() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_ngram_analyzer() {
     test_setup();
@@ -110,9 +107,8 @@ async fn test_create_and_drop_ngram_analyzer() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_list_analyzer() {
     test_setup();
@@ -141,9 +137,8 @@ async fn test_list_analyzer() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_exists() {
     test_setup();

--- a/tests/aql.rs
+++ b/tests/aql.rs
@@ -18,9 +18,8 @@ struct User {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_aql_str() {
     test_setup();
@@ -35,9 +34,8 @@ async fn test_aql_str() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_aql() {
     test_setup();
@@ -52,9 +50,8 @@ async fn test_aql() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_aql_bind_vars() {
     test_setup();
@@ -71,9 +68,8 @@ async fn test_aql_bind_vars() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_aql_try_bind() {
     test_setup();

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -19,9 +19,8 @@ use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup
 pub mod common;
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_collection() {
     test_setup();
@@ -37,9 +36,8 @@ async fn test_get_collection() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_db_from_collection() {
     test_setup();
@@ -55,9 +53,8 @@ async fn test_get_db_from_collection() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_collection() {
     test_setup();
@@ -92,9 +89,8 @@ async fn test_create_and_drop_collection() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_edge_collection() {
     test_setup();
@@ -128,9 +124,8 @@ async fn test_create_and_drop_edge_collection() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_truncate_collection() {
     test_setup();
@@ -149,9 +144,8 @@ async fn test_truncate_collection() {
     coll.drop().await.expect("Fail to drop the collection");
 }
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_properties() {
     test_setup();
@@ -189,9 +183,8 @@ async fn test_get_properties() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_document_count() {
     test_setup();
@@ -231,9 +224,8 @@ async fn test_get_document_count() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_statistics() {
     test_setup();
@@ -270,9 +262,8 @@ async fn test_get_statistics() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_revision_id() {
     test_setup();
@@ -302,9 +293,8 @@ async fn test_get_revision_id() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_checksum() {
     test_setup();
@@ -370,9 +360,8 @@ async fn test_get_checksum() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_load() {
     test_setup();
@@ -418,9 +407,8 @@ async fn test_put_load() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_unload() {
     test_setup();
@@ -447,9 +435,8 @@ async fn test_put_unload() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_load_indexes_into_memory() {
     test_setup();
@@ -466,9 +453,8 @@ async fn test_put_load_indexes_into_memory() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_changes_properties() {
     test_setup();
@@ -498,9 +484,8 @@ async fn test_put_changes_properties() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_rename() {
     test_setup();
@@ -523,9 +508,8 @@ async fn test_put_rename() {
 
 #[cfg(feature = "rocksdb")]
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_recalculate() {
     test_setup();
@@ -543,9 +527,8 @@ async fn test_put_recalculate() {
 
 #[cfg(any(feature = "mmfiles"))]
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_put_rotate_journal() {
     test_setup();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -54,36 +54,16 @@ pub async fn connection() -> arangors::Connection {
         .unwrap()
 }
 
-#[cfg(any(feature = "reqwest_async", feature = "reqwest_blocking"))]
 #[maybe_async::maybe_async]
 pub async fn collection<'a>(
     conn: &'a arangors::Connection,
     name: &str,
-) -> Collection<uclient::reqwest::ReqwestClient> {
+) -> Collection {
     let database = conn.db("test_db").await.unwrap();
 
     match database.drop_collection(name).await {
         _ => {}
     };
-    database
-        .create_collection(name)
-        .await
-        .expect("Fail to create the collection");
-    database.collection(name).await.unwrap()
-}
-
-#[cfg(feature = "surf_async")]
-#[maybe_async::maybe_async]
-pub async fn collection<'a>(
-    conn: &'a arangors::Connection,
-    name: &str,
-) -> Collection<uclient::surf::SurfClient> {
-    let database = conn.db("test_db").await.unwrap();
-
-    match database.drop_collection(name).await {
-        _ => {}
-    };
-
     database
         .create_collection(name)
         .await

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,7 +1,6 @@
 #![allow(unused_imports)]
 #![allow(unused_parens)]
 use pretty_assertions::assert_eq;
-use uclient::ClientExt;
 
 use arangors::{connection::Permission, Connection};
 use common::{
@@ -12,9 +11,8 @@ use common::{
 pub mod common;
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_list_databases() {
     test_setup();
@@ -32,9 +30,8 @@ async fn test_list_databases() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_url() {
     test_setup();
@@ -50,9 +47,8 @@ async fn test_get_url() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_database() {
     test_setup();
@@ -64,9 +60,8 @@ async fn test_get_database() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_basic_auth() {
     test_setup();
@@ -84,9 +79,8 @@ async fn test_basic_auth() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_jwt() {
     test_setup();

--- a/tests/database.rs
+++ b/tests/database.rs
@@ -14,9 +14,8 @@ pub mod common;
 const NEW_DB_NAME: &str = "example";
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_database() {
     test_setup();
@@ -44,9 +43,8 @@ async fn test_create_and_drop_database() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_fetch_current_database_info() {
     test_setup();
@@ -71,9 +69,8 @@ async fn test_fetch_current_database_info() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_version() {
     test_setup();

--- a/tests/document.rs
+++ b/tests/document.rs
@@ -23,9 +23,8 @@ pub mod common;
 
 #[cfg(not(feature = "arango3_7"))]
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_post_create_document() {
     test_setup();
@@ -143,9 +142,8 @@ async fn test_post_create_document() {
 /// TODO need to use CI to validate this test
 #[cfg(any(feature = "arango3_7"))]
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_post_create_document_3_7() {
     test_setup();
@@ -325,9 +323,8 @@ async fn test_post_create_document_3_7() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_read_document() {
     test_setup();
@@ -376,9 +373,8 @@ async fn test_get_read_document() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_get_read_document_header() {
     test_setup();
@@ -453,9 +449,8 @@ async fn test_get_read_document_header() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_patch_update_document() {
     test_setup();
@@ -530,9 +525,8 @@ async fn test_patch_update_document() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_post_replace_document() {
     test_setup();
@@ -642,9 +636,8 @@ async fn test_post_replace_document() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_delete_remove_document() {
     test_setup();
@@ -760,9 +753,8 @@ async fn test_delete_remove_document() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_document_deserialization() {
     use serde::{Deserialize, Serialize};

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -4,7 +4,6 @@
 use log::trace;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
-use uclient::ClientExt;
 
 use arangors::{
     collection::{
@@ -22,14 +21,14 @@ use crate::common::{collection, connection};
 pub mod common;
 
 #[maybe_async::maybe_async]
-async fn drop_all_graphs<C: ClientExt>(db: &Database<C>, names: Vec<&str>) {
+async fn drop_all_graphs(db: &Database, names: Vec<&str>) {
     for name in names.iter() {
         drop_graph(db, name).await;
     }
 }
 
 #[maybe_async::maybe_async]
-async fn drop_graph<C: ClientExt>(db: &Database<C>, name: &str) {
+async fn drop_graph(db: &Database, name: &str) {
     match db.drop_graph(name, false).await {
         Ok(()) => (),
         Err(err) => println!("Failed to drop graph: {:?}", err),
@@ -37,9 +36,8 @@ async fn drop_graph<C: ClientExt>(db: &Database<C>, name: &str) {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_simple_graph() {
     test_setup();
@@ -66,9 +64,8 @@ async fn test_simple_graph() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_complex_graph() {
     test_setup();
@@ -111,9 +108,8 @@ async fn test_complex_graph() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_graph_retrieval() {
     test_setup();

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -20,9 +20,8 @@ use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup
 pub mod common;
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_persistent_index() {
     test_setup();
@@ -66,9 +65,8 @@ async fn test_persistent_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_hash_index() {
     test_setup();
@@ -112,9 +110,8 @@ async fn test_hash_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_skiplist_index() {
     test_setup();
@@ -158,9 +155,8 @@ async fn test_skiplist_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_geo_index() {
     test_setup();
@@ -193,9 +189,8 @@ async fn test_geo_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_ttl_index() {
     test_setup();
@@ -228,9 +223,8 @@ async fn test_ttl_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_fulltext_index() {
     test_setup();
@@ -263,9 +257,8 @@ async fn test_fulltext_index() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_list_indexes() {
     test_setup();

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -4,7 +4,6 @@ use log::trace;
 use maybe_async::maybe_async;
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
-use uclient::ClientExt;
 
 use crate::common::{collection, connection};
 use arangors::{
@@ -23,10 +22,10 @@ use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup
 pub mod common;
 
 #[maybe_async]
-async fn create_transaction<C: ClientExt>(
-    database: &Database<C>,
+async fn create_transaction(
+    database: &Database,
     collection_name: String,
-) -> Result<Transaction<C>, ClientError> {
+) -> Result<Transaction, ClientError> {
     database
         .begin_transaction(
             TransactionSettings::builder()
@@ -42,7 +41,7 @@ async fn create_transaction<C: ClientExt>(
 }
 
 #[maybe_async]
-async fn create_document<C: ClientExt>(tx: &Transaction<C>) -> Result<String, ClientError> {
+async fn create_document(tx: &Transaction) -> Result<String, ClientError> {
     let test_doc: Document<Value> = Document::new(json!({
         "user_name":"test21",
         "user_name":"test21_pwd",
@@ -58,9 +57,8 @@ async fn create_document<C: ClientExt>(tx: &Transaction<C>) -> Result<String, Cl
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_start_transaction() {
     test_setup();
@@ -80,9 +78,8 @@ async fn test_start_transaction() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_abort_transaction() {
     test_setup();
@@ -113,9 +110,8 @@ async fn test_abort_transaction() {
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_commit_transaction() {
     test_setup();

--- a/tests/view.rs
+++ b/tests/view.rs
@@ -6,7 +6,6 @@ use crate::common::{collection, connection};
 use log::{info, trace};
 use maybe_async::maybe_async;
 use pretty_assertions::assert_eq;
-use uclient::ClientExt;
 
 use arangors::view::{ArangoSearchViewLink, ArangoSearchViewPropertiesOptions, ViewOptions};
 use arangors::{
@@ -23,8 +22,8 @@ use common::{get_arangodb_host, get_normal_password, get_normal_user, test_setup
 pub mod common;
 
 #[maybe_async]
-async fn create_view<C: ClientExt>(
-    database: &Database<C>,
+async fn create_view(
+    database: &Database,
     view_name: String,
     collection_name: String,
 ) -> Result<View, ClientError> {
@@ -52,9 +51,8 @@ async fn create_view<C: ClientExt>(
 }
 
 #[maybe_async::test(
-    any(feature = "reqwest_blocking"),
-    async(any(feature = "reqwest_async"), tokio::test),
-    async(any(feature = "surf_async"), async_std::test)
+    feature = "blocking",
+    async(not(feature = "blocking"), tokio::test),
 )]
 async fn test_create_and_drop_view() {
     test_setup();
@@ -77,9 +75,8 @@ async fn test_create_and_drop_view() {
 }
 
 // #[maybe_async::test(
-//     any(feature = "reqwest_blocking"),
-//     async(any(feature = "reqwest_async"), tokio::test),
-//     async(any(feature = "surf_async"), async_std::test)
+//     feature = "blocking",
+//     async(not(feature = "blocking"), tokio::test),
 // )]
 // async fn test_list_view() {
 //     test_setup();
@@ -113,9 +110,8 @@ async fn test_create_and_drop_view() {
 // }
 
 // #[maybe_async::test(
-//     any(feature = "reqwest_blocking"),
-//     async(any(feature = "reqwest_async"), tokio::test),
-//     async(any(feature = "surf_async"), async_std::test)
+//     feature = "blocking",
+//     async(not(feature = "blocking"), tokio::test),
 // )]
 // async fn update_properties() {
 //     test_setup();


### PR DESCRIPTION
Currently `arangors` has issues with its feature system and its `uclient` and `maybe_async` dependencies.

To have better feature gates and simpler API I made this branch in my fork to avoid the `async`/`blocking` issues as well as the `rustls` problem.

I don't know if this can be useful or if it must replace the current `arangors` implementation but here it is.

I removed entirely the `surf` ecosystem and the option to pick a custom one. With this choice the feature gate system is much better and *additive*.

I'll use this version for my library [aragog](http://crates.io/crates/aragog) which needs simpler features.