### PR TITLE
Add GeoJSON Analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,9 +315,8 @@ println!("{:?}", resp);
 Contributions and feed back are welcome following Github workflow.
 
 Setup instructions:
-1. Install a local ArangoDB, port 8529
-2. Create a database "test_db"
-3. Create a user with "username" and password "password", or set `ARANGO_USER` and `ARANGO_PASSWORD`
+1. Install a local ArangoDB, version 3.8 or above, port 8529.  Use `docker compose`.
+2. Run `tests/init_db.sh`
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ println!("{:?}", resp);
 
 Contributions and feed back are welcome following Github workflow.
 
+Setup instructions:
+1. Install a local ArangoDB, port 8529
+2. Create a database "test_db"
+3. Create a user with "username" and password "password", or set `ARANGO_USER` and `ARANGO_PASSWORD`
+
 ### License
 
 `arangors` is provided under the MIT license. See [LICENSE](./LICENSE).

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -24,6 +24,14 @@ pub enum NgramStreamType {
     Utf8,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum GeoJsonType {
+    Shape,
+    Centroid,
+    Point,
+}
+
 #[derive(Debug, Serialize, Deserialize, TypedBuilder, PartialEq)]
 #[builder(doc)]
 pub struct DelimiterAnalyzerProperties {
@@ -114,6 +122,17 @@ pub struct TextAnalyzerProperties {
     pub stemming: Option<bool>,
 }
 
+#[derive(Debug, Serialize, Deserialize, TypedBuilder, PartialEq)]
+#[builder(doc)]
+pub struct GeoJsonAnalyzerProperties {
+    /// Whether to index all GeoJSON geometry types, just the centroid, or just points
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub r#type: Option<GeoJsonType>,
+
+    // Skip the options as they "generally should remain unchanged"
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum AnalyzerInfo {
@@ -172,6 +191,16 @@ pub enum AnalyzerInfo {
 
         #[serde(skip_serializing_if = "Option::is_none")]
         properties: Option<TextAnalyzerProperties>,
+    },
+
+    Geojson {
+        name: String,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        features: Option<Vec<AnalyzerFeature>>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        properties: Option<GeoJsonAnalyzerProperties>,
     },
 }
 


### PR DESCRIPTION
Add support for GeoJSON search analyzer (Arango 3.8) plus test.

I skipped the options as I wasn't sure how to add hash map serialization, and also they are not normally tunable by end users.