### PR TITLE
Implement Clone for option types

### DIFF
--- a/src/collection/options.rs
+++ b/src/collection/options.rs
@@ -5,7 +5,7 @@ use typed_builder::TypedBuilder;
 use crate::collection::CollectionType;
 
 /// Options for create a collection
-#[derive(Serialize, PartialEq, TypedBuilder)]
+#[derive(Serialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateParameters {
@@ -39,7 +39,7 @@ where
     }
 }
 /// Options for create a collection
-#[derive(Serialize, PartialEq, TypedBuilder)]
+#[derive(Serialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateOptions<'a> {
@@ -221,7 +221,7 @@ fn is_true(x: &bool) -> bool {
     *x
 }
 
-#[derive(Debug, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder, PartialEq, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyOptions {
@@ -263,7 +263,7 @@ impl Default for KeyOptions {
 }
 
 /// Options for checksum
-#[derive(Serialize, Deserialize, PartialEq, TypedBuilder)]
+#[derive(Serialize, Deserialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct ChecksumOptions {
@@ -290,7 +290,7 @@ impl Default for ChecksumOptions {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertiesOptions {

--- a/src/connection/options.rs
+++ b/src/connection/options.rs
@@ -5,7 +5,7 @@ use typed_builder::TypedBuilder;
 use std::collections::HashMap;
 
 /// Options for create a collection
-#[derive(Serialize, PartialEq, TypedBuilder)]
+#[derive(Serialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 #[cfg(feature = "cluster")]

--- a/src/document/options.rs
+++ b/src/document/options.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Options for document insertion.
-#[derive(Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct InsertOptions {
@@ -70,7 +70,7 @@ impl Default for InsertOptions {
 }
 
 /// Options for document update,
-#[derive(Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateOptions {
@@ -124,7 +124,7 @@ impl Default for UpdateOptions {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum OverwriteMode {
     /// If a document with the specified _key value exists already,
@@ -166,7 +166,7 @@ pub enum OverwriteMode {
 }
 
 /// Options for document replace,
-#[derive(Debug, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Serialize, Deserialize, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplaceOptions {
@@ -206,7 +206,7 @@ impl Default for ReplaceOptions {
 }
 
 /// Options for document reading.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ReadOptions {
     /// If the “If-None-Match” header is given, then it must contain exactly one
@@ -227,7 +227,7 @@ impl Default for ReadOptions {
 }
 
 /// Options for document removes,
-#[derive(Debug, Serialize, Deserialize, TypedBuilder)]
+#[derive(Debug, Serialize, Deserialize, TypedBuilder, Clone)]
 #[builder(doc)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveOptions {


### PR DESCRIPTION
This derives the `Clone` trait for option types such as `InsertOptions`, `UpdateOptions`, etc.

I kept the referenced `enum` types to `Clone` only even when `Copy` was possible so as to not break potential future, non-copyable values. For example, `Copy` would have been possible with `OverwriteMode` but not with `ReadOptions`.