### PR TITLE
Cargo features: support both default TLS and Rust TLS for Reqwest through feature forwarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,14 @@ features = [ "rocksdb", "reqwest_async" ]
 status = "actively-developed"
 
 [features]
-default = [ "rocksdb", "reqwest_async" ]
+default = [ "rocksdb", "reqwest_async", "reqwest_default-tls" ]
 blocking = [ "maybe-async/is_sync" ]
-reqwest_async = [ "reqwest" ]
+reqwest_async = [ "dep:reqwest" ]
 reqwest_blocking = [ "reqwest/blocking", "blocking" ]
+reqwest_default-tls = [ "reqwest/default-tls" ]
+reqwest_rustls-tls = [ "reqwest/rustls-tls" ]
+reqwest_macos-system-configuration = [ "reqwest/macos-system-configuration" ]
+
 surf_async = [ "http-types", "surf" ]
 cluster = [ ]
 enterprise = [ ]
@@ -49,7 +53,8 @@ serde_repr = "0.1"
 
   [dependencies.reqwest]
   version = "0.12"
-  features = [ "gzip", "json" ]
+  default_features = false
+  features = [ "charset", "http2", "gzip", "json" ]
   optional = true
 
   [dependencies.surf]


### PR DESCRIPTION
With this change, `arangors` can support Rust TLS out of the box. Default configuration is effectively unchanged, using default TLS.

To support Rust TLS as TLS provider for `reqwest`, now all that has to be done is adding `arangors` as dependency with flags:
```toml
arangors = { ..., default-features = false, features = ["rocksdb", "reqwest_async", "reqwest_rustls-tls"]}
```

Native (Default) TLS can be forced manually in a similar manner with
```toml
arangors = { ..., default-features = false, features = ["rocksdb", "reqwest_async", "reqwest_default-tls"]}
```

Of course, the TLS provider can be switched independently of blocking/async mode.

The way to handle feature gate forwarding was inspired by [elasticsearch](https://docs.rs/crate/elasticsearch/8.5.0-alpha.1/features).