### PR TITLE
Add arangodb-oasis as a valid server for arangograph cloud

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -120,7 +120,12 @@ impl<S, C: ClientExt> GenericConnection<C, S> {
                 if server_value.eq_ignore_ascii_case("ArangoDB") {
                     trace!("Validate arangoDB server done.");
                     Ok(())
-                } else {
+                }
+                else if server_value.eq_ignore_ascii_case("arangodb-oasis") {
+                    trace!("Validate arangoDB Oasis server done.");
+                    Ok(())
+                }
+                else {
                     Err(ClientError::InvalidServer(server_value.to_owned()))
                 }
             }


### PR DESCRIPTION
We recently changed our infra setup to use ArangoGraph cloud instead of on-premise installation. 

Our connection utilities that work with the on-premise setup, did not work with the cloud instance.

Got an error- Server is not ArangoDB: arangodb-oasis

The root cause seemed to be occurring in server validation which does not take in account the name of the ArangoGraph cloud.

Made this change and tested locally with our own deployment in the ArangoDB Cloud.

